### PR TITLE
Fix Gimbal PID to avoid jitter

### DIFF
--- a/examples/gimbal/typeC.cpp
+++ b/examples/gimbal/typeC.cpp
@@ -118,8 +118,8 @@ void gimbalTask(void *arg) {
 
     pitch_ratio = dbus->mouse.y / 32767.0 * 7.5 / 7.0;
     yaw_ratio = -dbus->mouse.x / 32767.0 * 7.5 / 7.0;
-    pitch_ratio += dbus->ch3 / 18000.0 / 7.0;
-    yaw_ratio += -dbus->ch2 / 18000.0 / 7.0;
+    pitch_ratio = dbus->ch3 / 18000.0 / 7.0;
+    yaw_ratio = -dbus->ch2 / 18000.0 / 7.0;
     pitch_target =
         clip<float>(pitch_target + pitch_ratio, -gimbal_param->pitch_max_,
                     gimbal_param->pitch_max_);
@@ -136,7 +136,7 @@ void gimbalTask(void *arg) {
       pitch_diff = 0;
     }
 
-    gimbal->TargetRel(pitch_diff / 60, yaw_diff / 100);
+    gimbal->TargetRel(pitch_diff, yaw_diff);
 
     gimbal->Update();
     control::MotorCANBase::TransmitOutput(gimbal_motors, 2);

--- a/shared/libraries/gimbal.cpp
+++ b/shared/libraries/gimbal.cpp
@@ -30,7 +30,7 @@ Gimbal::Gimbal(gimbal_t gimbal)
       float yaw_omega_max_iout = 25000; // 10000
       float yaw_omega_max_out = 30000;
       pitch_theta_pid_param_ = new float[3]{15, 0, 0};
-      pitch_omega_pid_param_ = new float[3]{2900, 60, 0};
+      pitch_omega_pid_param_ = new float[3]{1800, 60, 0};
       yaw_theta_pid_param_ = new float[3]{26, 0, 0.3};
       yaw_omega_pid_param_ = new float[3]{3600, 20, 0};
       pitch_theta_pid_ = new ConstrainedPID(
@@ -154,6 +154,12 @@ void Gimbal::TargetAbs(float abs_pitch, float abs_yaw) {
 void Gimbal::TargetRel(float rel_pitch, float rel_yaw) {
   pitch_angle_ = pitch_motor_->GetTheta() + rel_pitch;
   yaw_angle_ = yaw_motor_->GetTheta() + rel_yaw;
+}
+
+void Gimbal::UpdateOffset(float pitch_offset, float yaw_offset) {
+  data_.pitch_offset_ =
+      wrap<float>(pitch_offset + data_.pitch_offset_, 0, 2 * PI);
+  data_.yaw_offset_ = wrap<float>(yaw_offset + data_.yaw_offset_, 0, 2 * PI);
 }
 
 } // namespace control

--- a/shared/libraries/gimbal.h
+++ b/shared/libraries/gimbal.h
@@ -82,6 +82,14 @@ public:
    */
   void TargetRel(float new_pitch, float new_yaw);
 
+  /**
+   * @brief update the offset of the gimbal
+   *
+   * @param pitch_offset new pitch offset
+   * @param yaw_offset   new yaw offset
+   */
+  void UpdateOffset(float pitch_offset, float yaw_offset);
+
 private:
   // acquired from user
   MotorCANBase *pitch_motor_ = nullptr;


### PR DESCRIPTION
In sometimes, PID's value is too large to cause some jitter here.