### PR TITLE
fix: immediately starts high-resolution timer in SetHighresClockTimer

### DIFF
--- a/boards/platform/stm32f4/src/bsp_os.cpp
+++ b/boards/platform/stm32f4/src/bsp_os.cpp
@@ -47,6 +47,14 @@ namespace bsp {
 
     void SetHighresClockTimer(TIM_HandleTypeDef* htim) {
         htim_os = htim;
+        // 立即启动定时器
+        // main.c 会先执行 MX_FREERTOS_Init()，此时并没有初始化 FreeRTOS 时基定时器。
+        // FreeRTOS 定时器会在 main.c 的 osKernelStart() 中初始化时基定时器。
+        // 但是 MotorCanBase.cpp 会执行断言 RM_ASSERT_TRUE(bsp::GetHighresTickMicroSec() != 0, "Highres timer not initialized")
+        // 所以我们需要提前初始化一次高精度定时器以使 MotorCANBase 的断言能够通过。
+        __HAL_TIM_SET_AUTORELOAD(htim_os, 0xffffffff);
+        __HAL_TIM_SET_COUNTER(htim_os, 0);
+        __HAL_TIM_ENABLE(htim_os);
     }
 
     uint16_t GetHighresTickMicroSec(void) {


### PR DESCRIPTION
确保在调用 SetHighresClockTimer 时立即启动高精度定时器，设置自动重装载值为最大计数并使能定时器，保证时钟计数器能够正常工作
