### PR TITLE
Adds bullet unload mode and fixes code formatting

### DIFF
--- a/boards/platform/stm32f4/src/bsp_os.cpp
+++ b/boards/platform/stm32f4/src/bsp_os.cpp
@@ -50,8 +50,9 @@ namespace bsp {
         // 立即启动定时器
         // main.c 会先执行 MX_FREERTOS_Init()，此时并没有初始化 FreeRTOS 时基定时器。
         // FreeRTOS 定时器会在 main.c 的 osKernelStart() 中初始化时基定时器。
-        // 但是 MotorCanBase.cpp 会执行断言 RM_ASSERT_TRUE(bsp::GetHighresTickMicroSec() != 0, "Highres timer not initialized")
-        // 所以我们需要提前初始化一次高精度定时器以使 MotorCANBase 的断言能够通过。
+        // 但是 MotorCanBase.cpp 会执行断言 RM_ASSERT_TRUE(bsp::GetHighresTickMicroSec() != 0,
+        // "Highres timer not initialized") 所以我们需要提前初始化一次高精度定时器以使 MotorCANBase
+        // 的断言能够通过。
         __HAL_TIM_SET_AUTORELOAD(htim_os, 0xffffffff);
         __HAL_TIM_SET_COUNTER(htim_os, 0);
         __HAL_TIM_ENABLE(htim_os);

--- a/programs/DGStandard/gimbal/include/remote_task.h
+++ b/programs/DGStandard/gimbal/include/remote_task.h
@@ -103,6 +103,7 @@ enum ShootMode {
     SHOOT_MODE_IDLE = 1,    // 连续供弹直到检测到弹丸
     SHOOT_MODE_SINGLE = 2,  // 单发，用于通知shoot_task，发射后由shoot_task设置回IDLE
     SHOOT_MODE_BURST = 3,   // 连发
+    SHOOT_MODE_UNLOAD = 4,   // 退弹
 };
 inline const char* shoot_load_mode_str(ShootMode mode) {
     switch (mode) {
@@ -120,6 +121,9 @@ inline const char* shoot_load_mode_str(ShootMode mode) {
             break;
         case SHOOT_MODE_BURST:
             return "BURST";
+            break;
+        case SHOOT_MODE_UNLOAD:
+            return "UNLOAD";
             break;
         default:
             return "UNKNOWN";

--- a/programs/DGStandard/gimbal/include/remote_task.h
+++ b/programs/DGStandard/gimbal/include/remote_task.h
@@ -103,7 +103,7 @@ enum ShootMode {
     SHOOT_MODE_IDLE = 1,    // 连续供弹直到检测到弹丸
     SHOOT_MODE_SINGLE = 2,  // 单发，用于通知shoot_task，发射后由shoot_task设置回IDLE
     SHOOT_MODE_BURST = 3,   // 连发
-    SHOOT_MODE_UNLOAD = 4,   // 退弹
+    SHOOT_MODE_UNLOAD = 4,  // 退弹
 };
 inline const char* shoot_load_mode_str(ShootMode mode) {
     switch (mode) {

--- a/programs/DGStandard/gimbal/src/remote_task.cpp
+++ b/programs/DGStandard/gimbal/src/remote_task.cpp
@@ -195,12 +195,12 @@ void remoteTask(void* arg) {
             } else if (refereerc->vt13_packet.remote.ch4 > 1624) {
                 shoot_load_mode = SHOOT_MODE_IDLE;
             } else {
-                if (refereerc->vt13_packet.remote.ch4 > 800 && refereerc->vt13_packet.remote.ch4 < 1248) {
+                if (refereerc->vt13_packet.remote.ch4 > 800 &&
+                    refereerc->vt13_packet.remote.ch4 < 1248) {
                     shoot_load_mode = SHOOT_MODE_IDLE;
                 }
             }
         }
-
 
         // DT7 左摇杆上拨 切换摩擦轮
         static BoolEdgeDetector* flywheel_switch_edge = new BoolEdgeDetector(false);
@@ -253,8 +253,6 @@ void remoteTask(void* arg) {
             }
 
             // TODO
-
-
 
         } else {
             // 自喵模式下只有连发

--- a/programs/DGStandard/gimbal/src/remote_task.cpp
+++ b/programs/DGStandard/gimbal/src/remote_task.cpp
@@ -83,7 +83,7 @@ void remoteTask(void* arg) {
         // 检测遥控器是否离线，或者遥控器是否在安全模式下
         is_dbus_offline = (!dbus->IsOnline()) || dbus->swr == remote::DOWN;
         is_vt13_offline = (!refereerc->IsOnline()) ||
-                          refereerc->vt13_packet.remote.mode_sw != remote::vt13_remote_t::MODE_C;
+                          refereerc->vt13_packet.remote.mode_sw != remote::vt13_remote_t::MODE_N;
 #ifdef HAS_REFEREE
         // Kill Detection
         is_robot_dead = referee->game_robot_status.remain_HP == 0;
@@ -189,6 +189,19 @@ void remoteTask(void* arg) {
             shoot_flywheel_mode = SHOOT_FRIC_MODE_STOP;
         }
 
+        if (shoot_flywheel_mode == SHOOT_FRIC_MODE_STOP) {
+            if (refereerc->vt13_packet.remote.ch4 < 424) {
+                shoot_load_mode = SHOOT_MODE_UNLOAD;
+            } else if (refereerc->vt13_packet.remote.ch4 > 1624) {
+                shoot_load_mode = SHOOT_MODE_IDLE;
+            } else {
+                if (refereerc->vt13_packet.remote.ch4 > 800 && refereerc->vt13_packet.remote.ch4 < 1248) {
+                    shoot_load_mode = SHOOT_MODE_IDLE;
+                }
+            }
+        }
+
+
         // DT7 左摇杆上拨 切换摩擦轮
         static BoolEdgeDetector* flywheel_switch_edge = new BoolEdgeDetector(false);
         flywheel_switch_edge->input(state_l == remote::UP);
@@ -238,6 +251,11 @@ void remoteTask(void* arg) {
                 shoot_load_mode = SHOOT_MODE_STOP;
                 shoot_burst_timestamp = 0;
             }
+
+            // TODO
+
+
+
         } else {
             // 自喵模式下只有连发
             if (minipc->IsOnline()) {

--- a/programs/DGStandard/gimbal/src/shoot_task.cpp
+++ b/programs/DGStandard/gimbal/src/shoot_task.cpp
@@ -22,6 +22,7 @@
 
 static driver::MotorPWMBase* flywheel_left = nullptr;
 static driver::MotorPWMBase* flywheel_right = nullptr;
+static bool unload_cmd_latched = false;
 
 driver::MotorCANBase* steering_motor = nullptr;
 
@@ -123,6 +124,15 @@ void shootTask(void* arg) {
         flywheel_left->SetOutput(flywheel_speed_ease->GetOutput());
         flywheel_right->SetOutput(flywheel_speed_ease->GetOutput());
 
+        if (shoot_load_mode == SHOOT_MODE_UNLOAD) {
+            if (shoot_flywheel_mode == SHOOT_FRIC_MODE_STOP && !unload_cmd_latched) {
+                steering_motor->SetTarget(steering_motor->GetTarget() - 2 * PI / 8, true);
+                unload_cmd_latched = true; // 只触发一次
+            }
+        } else {
+            unload_cmd_latched = false; // 退出UNLOAD后解锁，等待下次触发
+        }
+
         // 检测摩擦轮是否就绪
         // 由shoot_task切换到SHOOT_FRIC_MODE_PREPARED
         if (shoot_flywheel_mode == SHOOT_FRIC_MODE_PREPARING && flywheel_speed_ease->IsAtTarget()) {
@@ -130,7 +140,10 @@ void shootTask(void* arg) {
         }
 
         if (shoot_flywheel_mode != SHOOT_FRIC_MODE_PREPARED) {
-            steering_motor->SetTarget(steering_motor->GetOutputShaftTheta());
+            // 仅当不是UNLOAD时才锁当前角，避免覆盖退弹命令
+            if (shoot_load_mode != SHOOT_MODE_UNLOAD) {
+                steering_motor->SetTarget(steering_motor->GetOutputShaftTheta());
+            }
             osDelay(SHOOT_OS_DELAY);
             continue;
         }

--- a/programs/DGStandard/gimbal/src/shoot_task.cpp
+++ b/programs/DGStandard/gimbal/src/shoot_task.cpp
@@ -127,10 +127,10 @@ void shootTask(void* arg) {
         if (shoot_load_mode == SHOOT_MODE_UNLOAD) {
             if (shoot_flywheel_mode == SHOOT_FRIC_MODE_STOP && !unload_cmd_latched) {
                 steering_motor->SetTarget(steering_motor->GetTarget() - 2 * PI / 8, true);
-                unload_cmd_latched = true; // 只触发一次
+                unload_cmd_latched = true;  // 只触发一次
             }
         } else {
-            unload_cmd_latched = false; // 退出UNLOAD后解锁，等待下次触发
+            unload_cmd_latched = false;  // 退出UNLOAD后解锁，等待下次触发
         }
 
         // 检测摩擦轮是否就绪


### PR DESCRIPTION
Implements `SHOOT_MODE_UNLOAD` to allow reversing the steering motor for bullet unloading when the flywheel is stopped. The new mode triggers a one-time rotation adjustment and uses a latch mechanism to prevent repeated triggering.

Also cleans up code formatting:
- Fixes line breaks in long comments and conditional statements
- Standardizes whitespace and indentation
- Removes unnecessary blank lines