### PR TITLE
fix: 统一clang-format版本为18.1.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,11 +28,13 @@ jobs:
         tar -xf ~/gcc-arm-none-eabi.tar.xz --directory ~/arm-toolchain-v10-3 --strip-components=1
     - name: add system path
       run: echo "~/arm-toolchain-v10-3/bin" >> $GITHUB_PATH  # set environment variable
-    - name: install clang-format-18
+    # Pin exact patch version to match Homebrew / README (18.1.8).
+    # Ubuntu apt clang-format-18 is 18.1.3 and formats some macros differently.
+    - name: install clang-format 18.1.8
       run: |
-        sudo apt-get update
-        sudo apt-get install -y clang-format-18
-        sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-18 100
+        python3 -m pip install --user clang-format==18.1.8
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
+        "$HOME/.local/bin/clang-format" --version
     - name: cmake
       run: |
         mkdir build && cd build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,11 @@ jobs:
         tar -xf ~/gcc-arm-none-eabi.tar.xz --directory ~/arm-toolchain-v10-3 --strip-components=1
     - name: add system path
       run: echo "~/arm-toolchain-v10-3/bin" >> $GITHUB_PATH  # set environment variable
+    - name: install clang-format-18
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang-format-18
+        sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-18 100
     - name: cmake
       run: |
         mkdir build && cd build

--- a/README.md
+++ b/README.md
@@ -2,126 +2,134 @@
 
 ![arm](https://github.com/UIC-RoboMaster/UICRM-Embedded/workflows/arm%20build/badge.svg)
 
-Embedded system development @ BNU-HKBU UIC RoboMaster
+**UICRM-Embedded** is the STM32 embedded firmware repository for the BNBU-UIC RoboMaster team.  It contains general board-level drivers, algorithms and components, hardware examples, and robot programs. The project is built using C/C++, CMake, and the GNU Arm Embedded Toolchain.
+
+---
 
 ## User Guide
 
 You can follow the instructions below to set up the necessary environments for
 building the source code and flashing the embedded chips.
 
-### Set Up Environment
+### Setting Up the Environment
 
-**Install ARM Toolchain (manual)**
+**Install Arm GNU Toolchain**
 
-1. Go to the [official download page](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads) for ARM Toolchain.
-2. Download the pre-built toolchain according to your operating system.
-3. Decompress it to some directory and find an absolute path to the `bin` directory.
+1. Go to the [official download page](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads) for the Arm GNU Toolchain.
+2. Download the pre-built toolchain for your operating system.
+3. Extract it to a directory of your choice and note the path to the `bin` folder.
 
-    In my case: `/Users/yry0008/gcc-arm-none-eabi-10.3-2021.10/bin`.
+    For example: `/Users/yry0008/gcc-arm-none-eabi-10.3-2021.10/bin`.
 
-4. For Windows users, add the following line (replace `<path>` with the actual binary path found in step 3) to `PATH` environment variable.
+4. Add the `bin` directory to your `PATH` environment variable:
 
-    For Linux / Mac users, add the following line (replace `<path>` with the actual binary path found in step 3) to `~/.bashrc` for bash users or `~/.zshrc` for zsh users.
+    - **Windows**: Add `<path>` to the system `PATH` environment variable.
+    - **Linux / macOS**: Add the following line to `~/.bashrc` (bash) or `~/.zshrc` (zsh):
 
     ```sh
     export PATH=<path>:$PATH
     ```
 
-**Install OpenOCD (manual)**
-1. Go to the [official download page](https://gnutoolchains.com/arm-eabi/openocd/) for OpenOCD.
-2. Download the pre-built toolchain according to your operating system.
-3. Decompress it to some directory and find an absolute path to the `bin` directory.
+**Install OpenOCD**
 
-    In my case: `/Users/yry0008/openocd-0.11.0-2021.10/bin`.
-4. For Windows users, add the following line (replace `<path>` with the actual binary path found in step 3) to `PATH` environment variable. For Linux / Mac users, add the following line (replace `<path>` with the actual binary path found in step 3) to `~/.bashrc` for bash users or `~/.zshrc` for zsh users.
+1. Go to the [official download page](https://gnutoolchains.com/arm-eabi/openocd/) for OpenOCD.
+2. Download the pre-built binary for your operating system.
+3. Extract it to a directory of your choice and note the path to the `bin` folder.
+
+    For example: `/Users/yry0008/openocd-0.11.0-2021.10/bin`.
+
+4. Add the `bin` directory to your `PATH` environment variable:
+
+    - **Windows**: Add `<path>` to the system `PATH` environment variable.
+    - **Linux / macOS**: Add the following line to `~/.bashrc` (bash) or `~/.zshrc` (zsh):
 
     ```sh
     export PATH=<path>:$PATH
     ```
 
 **Install CMake**
-1. Go to the [official download page](https://cmake.org/download/) for CMake.
 
-> If you are using Clion, this step is not required.
+1. Download CMake from the [official download page](https://cmake.org/download/).
+
+> If you are using CLion, CMake is bundled — you can skip this step.
 
 **Install Ninja (Windows only)**
-1. Go to the [official download page](https://ninja-build.org)
+
+1. Download Ninja from the [official website](https://ninja-build.org).
 
 ### Compile Project
 
 **With CLion (Recommended)**
 
-You can directly open the project in CLion and build it.
-You need to set the path of the embedded toolchain in the CLion settings.
+You can open the project directly in CLion and build it.
+Set the path of the Arm GNU Toolchain in **Settings → Build, Execution, Deployment → CMake**.
 
-    In Windows, you should open `Settings`, `Build, Execution, Deployment`, `CMake`, then set the `Generator` to Ninja.
+> **Windows users**: Go to **Settings → Build, Execution, Deployment → CMake** and set **Generator** to `Ninja`.
 
-**Compile manually**
+**Building Manually**
 
-1. Go to your project root directory in a terminal.
-2. Run the following command to build the entire project.
+1. Open a terminal in the project root directory.
+2. Run the following commands to configure and build:
 
     ```sh
     mkdir build && cd build
     cmake -DCMAKE_BUILD_TYPE=Release ..
     make -j
     ```
-    In Windows, you should add the option to let cmake use ninja to build.
-    ```sh
-    cmake -DCMAKE_BUILD_TYPE=Release ... -G "Ninja"
-    ```
-    Using ninja to build.
-    ```sh
-    ninja -j
-    ```
-   
-    Change build type to `Debug` or `RelWithDebInfo` in order to debug with `gdb`. Note that `Debug` build could be much slower than the other two due to lack of compiler optimizations.
 
-### Flash Binary to Chip
+> **Windows users**: Use the `Ninja` generator:
+> ```sh
+> cmake -DCMAKE_BUILD_TYPE=Release .. -G "Ninja"
+> ninja -j
+> ```
 
-**Flash using CLion**
+Use `Debug` or `RelWithDebInfo` build types for GDB debugging. Note that `Debug` builds may be significantly slower due to disabled compiler optimizations.
 
-Choose the target you want to flash and click the `Run` button.
+### Flashing Firmware
 
-The default configuration is for CMSIS-DAP debugger. If you are using ST-LINK,
-you need to change the configuration in the CLion settings.
+**Flashing with CLion**
 
-**Flash using OpenOCD**
-TODO
+Select the target you want to flash and click the **Run** button.
 
-### Generate document
+The default configuration uses a CMSIS-DAP debugger. If you are using ST-LINK, update the debugger settings in the CLion run configuration.
+
+**Flashing with OpenOCD**
+
+You can also flash manually using OpenOCD. The repository includes OpenOCD
+configuration files in the `openocd/` directory for each MCU family.
+Refer to the [OpenOCD documentation](https://openocd.org/doc/html/Flash-Commands.html) for details.
+
+### Generating Documentation
 
 You will need [Doxygen](https://www.doxygen.nl/index.html).
 
-1. For Mac users, `brew install doxygen` could be a shortcut.
-2. For Ubuntu users, `sudo apt install doxygen` could be a shortcut.
-3. For Arch users, `sudo pacman -S doxygen` could be a shortcut.
-4. For Linux users, either use prebuilt binaries, or build from source following their compile manual.
+- **macOS**: `brew install doxygen`
+- **Ubuntu**: `sudo apt install doxygen`
+- **Arch**: `sudo pacman -S doxygen`
+- **Other Linux**: Use prebuilt binaries or build from source following the [compile manual](https://www.doxygen.nl/manual/install.html).
 
-To generate documentations after compiling the project.
+To generate documentation after building the project:
 
 - Run `make doc` in the `build/` directory
-- In windows, you need to run `ninja doc` in the `build/` directory
+- On Windows, run `ninja doc` in the `build/` directory
 
-To view the generated document:
+To view the generated documentation:
 
 - Run `firefox docs/html/index.html`, or
 - Open `docs/html/index.html` in your browser.
 
 ## Developer Guide
 
-Use the following guide when making contributions to this repo.
+Follow the guidelines below when contributing to this repository.
 
-### Edit the code
-You can use any editor you like, but we recommend using [CLion](https://www.jetbrains.com/clion/).
+### Editing the Code
 
-### Format Code
+You can use any editor, but we recommend [CLion](https://www.jetbrains.com/clion/).
 
-The continuous integration system will check the source code against
-a specific coding style. If the code does not follow the style, the
-formatting check will fail and the code will not be merged.
-All codes are required to be formatted correctly before merging. There are several
-integrated build commands that can help you automatically format your changes.
+### Formatting Code
+
+The continuous integration system will check the source code against a specific coding style. If the code does not follow the style, the formatting check will fail and the code will not be merged.
+All codes are required to be formatted correctly before merging. There are several integrated build commands that can help you automatically format your changes.
 
 **Prerequisite**: install `clang-format` **18.1.8**. CMake will not create the format target if `clang-format` is missing.
 
@@ -152,34 +160,30 @@ integrated build commands that can help you automatically format your changes.
   * [Official Installer](https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/LLVM-18.1.8-win64.exe) which files are going to locate `C:\Program Files\LLVM\bin\clang-format.exe` after installation.
 
 
-**Format using CLion**
+**Formatting with CLion**
 
-Choose the CMake target and compile it. CLion will automatically format the code for you.
+Select the formatting CMake target and build it. CLion will automatically format the code.
 1. `check-format`: Check `diff` between current source and formatted source (without modifying any source file)
 2. `format`: Format all source files (**Modifies** file in place)
 
-**Format manually**
+**Formatting Manually**
 
 You can run the following commands inside `build/` to format your changes.
 
 1. `make check-format`: Check `diff` between current source and formatted source (without modifying any source file)
 2. `make format`: Format all source files (**Modifies** file in place)
 
-### Debug with `gdb`
+### Debugging with GDB
 
-To debug embedded systems on a host machine, we would need a remote gdb server.
-There are 2 choices for such server, with tradeoffs of their own.
+Debugging an embedded target requires a remote GDB server. There are two options:
 
-* **`Clion Debugger`**
-  
+- **CLion Debugger** — The easiest approach. Select the target and click the **Debug** button in CLion.
 
-This is the easiest way to debug. Choose the target and Directly click the `Debug` button in CLion.
+- **OpenOCD** — Although directly using OpenOCD is possible, it is only recommended for advanced users.
 
-* **`OpenOCD`**
+---
 
-Thought directly using `openocd` is possible, but it is only recommended for advanced users.
-
-### Contribute to this repo
+### Contributing
 
 The main branch is protected. You need to create a new branch and make a pull request to merge your changes. You need to
 <u>pass the CI check (formatting check and build check)</u> before merging.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
-# UIC RoboMaster Embedded
+#  BNBU-UIC RoboMaster Embedded
 
 ![arm](https://github.com/UIC-RoboMaster/UICRM-Embedded/workflows/arm%20build/badge.svg)
+![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)
 
 **UICRM-Embedded** is the STM32 embedded firmware repository for the BNBU-UIC RoboMaster team.  It contains general board-level drivers, algorithms and components, hardware examples, and robot programs. The project is built using C/C++, CMake, and the GNU Arm Embedded Toolchain.
+
+[Architecture](#architecture) · [User Guide](#user-guide) · [Developer Guide](#developer-guide) · [Contributing](#contributing)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ You can follow the instructions below to set up the necessary environments for b
 |---|---|---|
 | Arm GNU Toolchain | ✅ | Cross-compiler for STM32 (GCC 10.3+) |
 | CMake (≥3.8) | ✅ | Build system; bundled with CLion |
-| Ninja | ✅ (Windows) | Build backend on Windows |
+| Ninja | ✅ | Build backend on Windows |
 | OpenOCD | ✅ | Debug & flash via CMSIS-DAP / ST-LINK |
 | CLion | ⭐ Recommended | IDE with integrated build, flash & debug |
 
 
-#### Install Arm GNU Toolchain**
+#### Install Arm GNU Toolchain
 
 1. Go to the [official download page](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads) for the Arm GNU Toolchain.
 2. Download the pre-built toolchain for your operating system.
@@ -79,7 +79,7 @@ You can follow the instructions below to set up the necessary environments for b
 
 Download and install CMake from [cmake.org/download](https://cmake.org/download/).
 
-#### Install Ninja (Windows only)
+#### Install Ninja
 
 > Skip this step if you are using **CLion** — it bundles Ninja.
 
@@ -188,12 +188,13 @@ All codes are required to be formatted correctly before merging. There are sever
 
 * For Linux users:
 
-  * Prefer the pinned LLVM binary (matches CI / macOS Homebrew `18.1.8`):
+  * Prefer the pinned LLVM binary:
     [x86_64](https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-18.04.tar.xz)
     [aarch64](https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang+llvm-18.1.8-aarch64-linux-gnu.tar.xz)
     ```bash
     tar -xf clang+llvm-18.1.8-*.tar.xz
-    export PATH=$PWD/clang+llvm-18.1.8-*/bin:$PATH
+    cp clang+llvm-18.1.8-*/bin/clang-format /usr/local/bin/
+    clang-format --version
     ```
   * Or: `pip install clang-format==18.1.8`
   * Avoid `apt install clang-format-18` on Ubuntu 24.04 — that package is **18.1.3**, not 18.1.8.
@@ -205,7 +206,8 @@ All codes are required to be formatted correctly before merging. There are sever
     [Apple Silicon](https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang+llvm-18.1.8-arm64-apple-macos11.tar.xz)
     ```bash
     tar -xf clang+llvm-18.1.8-arm64-apple-macos11.tar.xz
-    export PATH=$PWD/clang+llvm-18.1.8-arm64-apple-macos11/bin:$PATH
+    cp clang+llvm-18.1.8-arm64-apple-macos11/bin/clang-format /usr/local/bin/
+    clang-format --version
     ```
   * Or: `pip install clang-format==18.1.8`
 * For Windows users:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 ![arm](https://github.com/UIC-RoboMaster/UICRM-Embedded/workflows/arm%20build/badge.svg)
 ![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)
 
+[English](README.md) | [简体中文](README.zh-CN.md)
+
 </div>
 
 **UICRM-Embedded** is the STM32 embedded firmware repository for the BNBU-UIC RoboMaster team.  It contains general board-level drivers, algorithms and components, hardware examples, and robot programs. The project is built using C/C++, CMake, and the GNU Arm Embedded Toolchain.

--- a/README.md
+++ b/README.md
@@ -123,33 +123,30 @@ formatting check will fail and the code will not be merged.
 All codes are required to be formatted correctly before merging. There are several
 integrated build commands that can help you automatically format your changes.
 
-**Prerequisite**: install `clang-format` version 18. (otherwise CMake will not create the format target)
+**Prerequisite**: install `clang-format` **18.1.8**. CMake will not create the format target if `clang-format` is missing.
 
 * For Linux users:
 
-  * Recommend`sudo apt install clang-format-18`
-  
-  * LLVM released packages(fallback)
-    [x86_64 (most common)](https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-22.04.tar.xz)
-    [aarch64 (ARM64)](https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang+llvm-18.1.8-aarch64-linux-gnu.tar.xz)
-    Install by:
+  * Prefer the pinned LLVM binary (matches CI / macOS Homebrew `18.1.8`):
+    [x86_64](https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-18.04.tar.xz)
+    [aarch64](https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang+llvm-18.1.8-aarch64-linux-gnu.tar.xz)
     ```bash
     tar -xf clang+llvm-18.1.8-*.tar.xz
-    export PATH=$PWD/clang+llvm-18.1.8/bin:$PATH
+    export PATH=$PWD/clang+llvm-18.1.8-*/bin:$PATH
     ```
-    
+  * Or: `pip install clang-format==18.1.8`
+  * Avoid `apt install clang-format-18` on Ubuntu 24.04 — that package is **18.1.3**, not 18.1.8.
   
 * For Mac users:
 
-  * [x86_64 (Intel Mac)](https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang+llvm-18.1.8-x86_64-apple-darwin.tar.xz)
-    [x86_64 (Apple Silicon)](https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang+llvm-18.1.8-arm64-apple-darwin.tar.xz)
-    Install by:
-    
+  * Recommend: `brew install llvm@18` then ensure `clang-format` 18.1.8 is on `PATH`
+  * Or official package:
+    [Apple Silicon](https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang+llvm-18.1.8-arm64-apple-macos11.tar.xz)
     ```bash
-    tar -xf clang+llvm-18.1.8-*.tar.xz
-    export PATH=$PWD/clang+llvm-18.1.8/bin:$PATH
+    tar -xf clang+llvm-18.1.8-arm64-apple-macos11.tar.xz
+    export PATH=$PWD/clang+llvm-18.1.8-arm64-apple-macos11/bin:$PATH
     ```
-
+  * Or: `pip install clang-format==18.1.8`
 * For Windows users:
 
   * [Official Installer](https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/LLVM-18.1.8-win64.exe) which files are going to locate `C:\Program Files\LLVM\bin\clang-format.exe` after installation.

--- a/README.md
+++ b/README.md
@@ -36,10 +36,18 @@ uicrm/
 
 ## User Guide
 
-You can follow the instructions below to set up the necessary environments for
-building the source code and flashing the embedded chips.
+You can follow the instructions below to set up the necessary environments for building the source code and flashing the embedded chips.
 
-### Setting Up the Environment
+### 1. Requirement
+
+| Tool | Required | Note |
+|---|---|---|
+| Arm GNU Toolchain | ✅ | Cross-compiler for STM32 (GCC 10.3+) |
+| CMake (≥3.8) | ✅ | Build system; bundled with CLion |
+| Ninja | ✅ (Windows) | Build backend on Windows |
+| OpenOCD | ✅ | Debug & flash via CMSIS-DAP / ST-LINK |
+| CLion | ⭐ Recommended | IDE with integrated build, flash & debug |
+
 
 **Install Arm GNU Toolchain**
 
@@ -71,80 +79,107 @@ building the source code and flashing the embedded chips.
     - **Windows**: Add `<path>` to the system `PATH` environment variable.
     - **Linux / macOS**: Add the following line to `~/.bashrc` (bash) or `~/.zshrc` (zsh):
 
-    ```sh
-    export PATH=<path>:$PATH
-    ```
+      ```sh
+      export PATH=<path-to-bin>:$PATH
+      ```
 
 **Install CMake**
 
-1. Download CMake from the [official download page](https://cmake.org/download/).
+> Skip this step if you are using **CLion** — it bundles CMake.
 
-> If you are using CLion, CMake is bundled — you can skip this step.
+Download and install CMake from [cmake.org/download](https://cmake.org/download/).
 
 **Install Ninja (Windows only)**
 
-1. Download Ninja from the [official website](https://ninja-build.org).
+> Skip this step if you are using **CLion** — it bundles Ninja.
 
-### Compile Project
+Download Ninja from [ninja-build.org](https://ninja-build.org) and place it on your `PATH`.
 
-**With CLion (Recommended)**
+**Install OpenOCD**
 
-You can open the project directly in CLion and build it.
-Set the path of the Arm GNU Toolchain in **Settings → Build, Execution, Deployment → CMake**.
+1. Download the pre-built binary from [gnutoolchains.com/arm-eabi/openocd](https://gnutoolchains.com/arm-eabi/openocd/).
+2. Extract the archive and note the path to the `bin` folder — for example:
 
-> **Windows users**: Go to **Settings → Build, Execution, Deployment → CMake** and set **Generator** to `Ninja`.
-
-**Building Manually**
-
-1. Open a terminal in the project root directory.
-2. Run the following commands to configure and build:
-
-    ```sh
-    mkdir build && cd build
-    cmake -DCMAKE_BUILD_TYPE=Release ..
-    make -j
+    ```
+    /Users/yourname/openocd-0.12.0/bin
     ```
 
-> **Windows users**: Use the `Ninja` generator:
+3. Add the `bin` directory to your `PATH` (same procedure as the toolchain above).
+
+Verify your setup by running these commands in a terminal:
+
+```sh
+arm-none-eabi-gcc --version
+cmake --version
+openocd --version
+```
+
+### 2. Building the Project
+
+**Option A — CLion (Recommended)**
+
+1. Open the project root in CLion.
+2. Go to **Settings → Build, Execution, Deployment → CMake** and set the Arm GNU Toolchain path.
+3. On **Windows**, also set **Generator** to `Ninja`.
+4. Select a build target from the toolbar and click **Build**.
+
+**Option B — Command Line**
+
+```sh
+cd uicrm-embedded
+mkdir build && cd build
+cmake -DCMAKE_BUILD_TYPE=Release ..
+make -j$(nproc)
+```
+
+> **Windows**: Use the `Ninja` generator:
 > ```sh
 > cmake -DCMAKE_BUILD_TYPE=Release .. -G "Ninja"
 > ninja -j
 > ```
 
-Use `Debug` or `RelWithDebInfo` build types for GDB debugging. Note that `Debug` builds may be significantly slower due to disabled compiler optimizations.
+Use `Debug` or `RelWithDebInfo` instead of `Release` when you need GDB debugging.
+Note that `Debug` builds run significantly slower due to disabled optimizations.
 
-### Flashing Firmware
+### 3. Flashing Firmware
 
-**Flashing with CLion**
+**Option A — CLion (Recommended)**
 
-Select the target you want to flash and click the **Run** button.
+Select your target and click the **Run** button (or **Debug** for step-through debugging).
 
-The default configuration uses a CMSIS-DAP debugger. If you are using ST-LINK, update the debugger settings in the CLion run configuration.
+The default configuration assumes a **CMSIS-DAP** debugger. If you are using **ST-LINK**, change the debug probe in the CLion run configuration.
 
-**Flashing with OpenOCD**
+**Option B — Command Line (OpenOCD)**
 
-You can also flash manually using OpenOCD. The repository includes OpenOCD
-configuration files in the `openocd/` directory for each MCU family.
-Refer to the [OpenOCD documentation](https://openocd.org/doc/html/Flash-Commands.html) for details.
+The repository provides OpenOCD configuration files in `openocd/` for each MCU family. 
+For example, to flash a DJI_Board_TypeC (STM32F4):
 
-### Generating Documentation
+```sh
+openocd -f openocd/stm32f4/daplink.cfg
+```
 
-You will need [Doxygen](https://www.doxygen.nl/index.html).
+See [OpenOCD Flash Commands](https://openocd.org/doc/html/Flash-Commands.html) for details.
+
+
+### 4. Generating Documentation
+
+Install [Doxygen](https://www.doxygen.nl/index.html):
 
 - **macOS**: `brew install doxygen`
 - **Ubuntu**: `sudo apt install doxygen`
 - **Arch**: `sudo pacman -S doxygen`
-- **Other Linux**: Use prebuilt binaries or build from source following the [compile manual](https://www.doxygen.nl/manual/install.html).
 
-To generate documentation after building the project:
+Then build the docs:
 
-- Run `make doc` in the `build/` directory
-- On Windows, run `ninja doc` in the `build/` directory
+```sh
+cd build
+make doc
+# or: ninja doc (Windows)
+```
 
-To view the generated documentation:
+Open `docs/html/index.html` in your browser to view the result.
 
-- Run `firefox docs/html/index.html`, or
-- Open `docs/html/index.html` in your browser.
+---
 
 ## Developer Guide
 
@@ -211,7 +246,7 @@ Debugging an embedded target requires a remote GDB server. There are two options
 
 ---
 
-### Contributing
+## Contributing
 
 The main branch is protected. You need to create a new branch and make a pull request to merge your changes. You need to
 <u>pass the CI check (formatting check and build check)</u> before merging.

--- a/README.md
+++ b/README.md
@@ -58,43 +58,49 @@ You can follow the instructions below to set up the necessary environments for b
 
 #### Install Arm GNU Toolchain
 
-1. Go to the [official download page](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads) for the Arm GNU Toolchain.
-2. Download the pre-built toolchain for your operating system.
-3. Extract it to a directory of your choice and note the path to the `bin` folder.
+- **macOS**: `brew install --cask gcc-arm-embedded`
+- **Linux / Windows**: download from the [Arm GNU downloads page](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads).
 
-    For example: `/Users/yry0008/gcc-arm-none-eabi-10.3-2021.10/bin`.
+  Extract the archive and note the path to the `bin` folder — for example:
 
-4. Add the `bin` directory to your `PATH` environment variable:
+  ```
+  /Users/yourname/gcc-arm-none-eabi-10.3-2021.10/bin
+  ```
 
-    - **Windows**: Add `<path>` to the system `PATH` environment variable.
-    - **Linux / macOS**: Add the following line to `~/.bashrc` (bash) or `~/.zshrc` (zsh):
+  Add the `bin` directory to your `PATH` (add to `~/.bashrc` or `~/.zshrc`):
 
-    ```sh
-    export PATH=<path>:$PATH
-    ```
+  ```sh
+  export PATH=<path-to-bin>:$PATH
+  ```
 
 #### Install CMake
 
 > Skip this step if you are using **CLion** — it bundles CMake.
 
-Download and install CMake from [cmake.org/download](https://cmake.org/download/).
+- **macOS**: `brew install cmake`
+- **Linux**: `sudo apt install cmake` (Ubuntu) / `sudo pacman -S cmake` (Arch)
+- **Windows**: download from [cmake.org/download](https://cmake.org/download/)
 
 #### Install Ninja
 
 > Skip this step if you are using **CLion** — it bundles Ninja.
 
-Download Ninja from [ninja-build.org](https://ninja-build.org) and place it on your `PATH`.
+- **macOS**: `brew install ninja`
+- **Linux**: `sudo apt install ninja-build` (Ubuntu) / `sudo pacman -S ninja` (Arch)
+- **Windows**: download from [ninja-build.org](https://ninja-build.org) and place it on your `PATH`
 
 #### Install OpenOCD
 
-1. Download the pre-built binary from [gnutoolchains.com/arm-eabi/openocd](https://gnutoolchains.com/arm-eabi/openocd/).
-2. Extract the archive and note the path to the `bin` folder — for example:
+- **macOS**: `brew install open-ocd`
+- **Linux / Windows**: download from [gnutoolchains.com/arm-eabi/openocd](https://gnutoolchains.com/arm-eabi/openocd/).
 
-    ```
-    /Users/yourname/openocd-0.12.0/bin
-    ```
+  Extract the archive and note the path to the `bin` folder — for example:
 
-3. Add the `bin` directory to your `PATH` (same procedure as the toolchain above).
+  ```
+  /Users/yourname/openocd-0.12.0/bin
+  ```
+
+  Add the `bin` directory to your `PATH` (same procedure as the toolchain above).
 
 **Verify your setup by running these commands in a terminal:**
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
-#  BNBU-UIC RoboMaster Embedded
+<div align="center">
+
+# BNBU-UIC RoboMaster Embedded
 
 ![arm](https://github.com/UIC-RoboMaster/UICRM-Embedded/workflows/arm%20build/badge.svg)
 ![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)
+
+</div>
 
 **UICRM-Embedded** is the STM32 embedded firmware repository for the BNBU-UIC RoboMaster team.  It contains general board-level drivers, algorithms and components, hardware examples, and robot programs. The project is built using C/C++, CMake, and the GNU Arm Embedded Toolchain.
 
@@ -41,7 +45,7 @@ uicrm/
 
 You can follow the instructions below to set up the necessary environments for building the source code and flashing the embedded chips.
 
-### 1. Requirement
+### 1. Requirements
 
 | Tool | Required | Note |
 |---|---|---|
@@ -52,7 +56,7 @@ You can follow the instructions below to set up the necessary environments for b
 | CLion | ⭐ Recommended | IDE with integrated build, flash & debug |
 
 
-**Install Arm GNU Toolchain**
+#### Install Arm GNU Toolchain**
 
 1. Go to the [official download page](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads) for the Arm GNU Toolchain.
 2. Download the pre-built toolchain for your operating system.
@@ -69,36 +73,19 @@ You can follow the instructions below to set up the necessary environments for b
     export PATH=<path>:$PATH
     ```
 
-**Install OpenOCD**
-
-1. Go to the [official download page](https://gnutoolchains.com/arm-eabi/openocd/) for OpenOCD.
-2. Download the pre-built binary for your operating system.
-3. Extract it to a directory of your choice and note the path to the `bin` folder.
-
-    For example: `/Users/yry0008/openocd-0.11.0-2021.10/bin`.
-
-4. Add the `bin` directory to your `PATH` environment variable:
-
-    - **Windows**: Add `<path>` to the system `PATH` environment variable.
-    - **Linux / macOS**: Add the following line to `~/.bashrc` (bash) or `~/.zshrc` (zsh):
-
-      ```sh
-      export PATH=<path-to-bin>:$PATH
-      ```
-
-**Install CMake**
+#### Install CMake
 
 > Skip this step if you are using **CLion** — it bundles CMake.
 
 Download and install CMake from [cmake.org/download](https://cmake.org/download/).
 
-**Install Ninja (Windows only)**
+#### Install Ninja (Windows only)
 
 > Skip this step if you are using **CLion** — it bundles Ninja.
 
 Download Ninja from [ninja-build.org](https://ninja-build.org) and place it on your `PATH`.
 
-**Install OpenOCD**
+#### Install OpenOCD
 
 1. Download the pre-built binary from [gnutoolchains.com/arm-eabi/openocd](https://gnutoolchains.com/arm-eabi/openocd/).
 2. Extract the archive and note the path to the `bin` folder — for example:
@@ -109,7 +96,7 @@ Download Ninja from [ninja-build.org](https://ninja-build.org) and place it on y
 
 3. Add the `bin` directory to your `PATH` (same procedure as the toolchain above).
 
-Verify your setup by running these commands in a terminal:
+**Verify your setup by running these commands in a terminal:**
 
 ```sh
 arm-none-eabi-gcc --version
@@ -119,14 +106,14 @@ openocd --version
 
 ### 2. Building the Project
 
-**Option A — CLion (Recommended)**
+#### Option A — CLion (Recommended)
 
 1. Open the project root in CLion.
 2. Go to **Settings → Build, Execution, Deployment → CMake** and set the Arm GNU Toolchain path.
 3. On **Windows**, also set **Generator** to `Ninja`.
 4. Select a build target from the toolbar and click **Build**.
 
-**Option B — Command Line**
+#### Option B — Command Line
 
 ```sh
 cd uicrm-embedded
@@ -146,13 +133,13 @@ Note that `Debug` builds run significantly slower due to disabled optimizations.
 
 ### 3. Flashing Firmware
 
-**Option A — CLion (Recommended)**
+#### Option A — CLion (Recommended)
 
 Select your target and click the **Run** button (or **Debug** for step-through debugging).
 
 The default configuration assumes a **CMSIS-DAP** debugger. If you are using **ST-LINK**, change the debug probe in the CLion run configuration.
 
-**Option B — Command Line (OpenOCD)**
+#### Option B — Command Line (OpenOCD)
 
 The repository provides OpenOCD configuration files in `openocd/` for each MCU family. 
 For example, to flash a DJI_Board_TypeC (STM32F4):

--- a/README.md
+++ b/README.md
@@ -6,6 +6,34 @@
 
 ---
 
+## Architecture
+
+```
+uicrm/
+├── boards/                  Shared libraries
+│   ├── base/                Board support packages (STM32CubeMX HAL) for 6 MCU boards
+│   ├── platform/            RTOS & HAL abstraction (stm32f1 / stm32f4 / stm32h7)
+│   ├── algorithm/           Control algorithms — PID, AHRS, Quaternion EKF, CRC, power limiting...
+│   ├── drivers/             Peripheral drivers — IMU, motors, DBUS/SBUS, OLED, RGB LED, Supercap...
+│   ├── components/          Robot subsystems — gimbal, chassis, shooter, referee UI
+│   └── third_party/         External libraries — MahonyAHRS, QuaternionEKF, SEGGER RTT...
+├── cmake/                   CMake modules — toolchain, build helpers, clang-format, Doxygen
+├── examples/                Standalone peripheral examples
+├── openocd/                 OpenOCD configs (stm32f1 / stm32f4 / stm32h7)
+├── programs/                Complete Robot firmware
+└── scripts/                 Utility scripts (launch.json generation, RTT viewer, formatting)
+```
+
+### Supported Hardware
+
+| MCU Family | Core | Boards |
+|---|---|---|
+| STM32F1 | Cortex-M3 | `F103_Nano_general`, `BulletExchanger_F103` |
+| STM32F4 | Cortex-M4 | `DJI_Board_TypeC_general` (F407), `DJI_Board_TypeA_general` (F427), `DM_MC01_general` (F446) |
+| STM32H7 | Cortex-M7 | `DM_MC02_general` (H723) |
+
+---
+
 ## User Guide
 
 You can follow the instructions below to set up the necessary environments for

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,267 @@
+<div align="center">
+
+# BNBU-UIC RoboMaster Embedded
+
+![arm](https://github.com/UIC-RoboMaster/UICRM-Embedded/workflows/arm%20build/badge.svg)
+![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)
+
+[English](README.md) | [简体中文](README.zh-CN.md)
+
+</div>
+
+**UICRM-Embedded** 是 BNBU-UIC RoboMaster 战队的 STM32 嵌入式固件仓库，包含通用板级驱动、算法与组件、硬件示例以及各机器人程序。项目使用 C/C++ 开发，CMake 构建，基于 GNU Arm Embedded Toolchain 编译。
+
+[项目架构](#项目架构) · [使用指南](#使用指南) · [开发指南](#开发指南) · [贡献指南](#贡献指南)
+
+---
+
+## 项目架构
+
+```
+uicrm/
+├── boards/                  共享库
+│   ├── base/                板级支持包（STM32CubeMX HAL），覆盖 6 款 MCU 板卡
+│   ├── platform/            RTOS 与 HAL 抽象层（stm32f1 / stm32f4 / stm32h7）
+│   ├── algorithm/           控制算法 — PID、AHRS、四元数 EKF、CRC、功率限制
+│   ├── drivers/             外设驱动 — IMU、电机、DBUS/SBUS、OLED、RGB LED、超级电容
+│   ├── components/          机器人子系统 — 云台、底盘、发射机构、裁判系统 UI
+│   └── third_party/         第三方库 — MahonyAHRS、QuaternionEKF、SEGGER RTT
+├── cmake/                   CMake 模块 — 工具链、构建辅助、clang-format、Doxygen
+├── examples/                独立外设示例（60+）
+├── openocd/                 OpenOCD 配置文件（stm32f1 / stm32f4 / stm32h7）
+├── programs/                完整机器人固件（12 款机器人）
+└── scripts/                 工具脚本（launch.json 生成、RTT 查看器、格式化）
+```
+
+### 支持的硬件
+
+| MCU 系列 | 内核 | 板卡 |
+|---|---|---|
+| STM32F1 | Cortex-M3 | `F103_Nano_general`、`BulletExchanger_F103` |
+| STM32F4 | Cortex-M4 | `DJI_Board_TypeC_general` (F407)、`DJI_Board_TypeA_general` (F427)、`DM_MC01_general` (F446) |
+| STM32H7 | Cortex-M7 | `DM_MC02_general` (H723) |
+
+---
+
+## 使用指南
+
+按照以下步骤搭建开发环境、构建固件并烧录到开发板。
+
+### 1. 环境要求
+
+| 工具 | 是否必需 | 说明 |
+|---|---|---|
+| Arm GNU Toolchain | ✅ | STM32 交叉编译器（GCC 10.3+） |
+| CMake (≥3.8) | ✅ | 构建系统；CLion 已内置 |
+| Ninja | ✅ | Windows 下的构建后端 |
+| OpenOCD | ✅ | 通过 CMSIS-DAP / ST-LINK 调试与烧录 |
+| CLion | ⭐ 推荐 | 集成构建、烧录、调试的 IDE |
+
+
+#### 安装 Arm GNU Toolchain
+
+- **macOS**：`brew install --cask gcc-arm-embedded`
+- **Linux / Windows**：从 [Arm GNU 下载页面](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads) 下载。
+
+  解压后记下 `bin` 目录的路径，例如：
+
+  ```
+  /Users/yourname/gcc-arm-none-eabi-10.3-2021.10/bin
+  ```
+
+  将 `bin` 目录加入 `PATH`（添加到 `~/.bashrc` 或 `~/.zshrc`）：
+
+  ```sh
+  export PATH=<path-to-bin>:$PATH
+  ```
+
+#### 安装 CMake
+
+> 如果使用 **CLion**，可跳过此步骤——CLion 已内置 CMake。
+
+- **macOS**：`brew install cmake`
+- **Linux**：`sudo apt install cmake`（Ubuntu）/ `sudo pacman -S cmake`（Arch）
+- **Windows**：从 [cmake.org/download](https://cmake.org/download/) 下载安装
+
+#### 安装 Ninja
+
+> 如果使用 **CLion**，可跳过此步骤——CLion 已内置 Ninja。
+
+- **macOS**：`brew install ninja`
+- **Linux**：`sudo apt install ninja-build`（Ubuntu）/ `sudo pacman -S ninja`（Arch）
+- **Windows**：从 [ninja-build.org](https://ninja-build.org) 下载并加入 `PATH`
+
+#### 安装 OpenOCD
+
+- **macOS**：`brew install open-ocd`
+- **Linux / Windows**：从 [gnutoolchains.com/arm-eabi/openocd](https://gnutoolchains.com/arm-eabi/openocd/) 下载。
+
+  解压后记下 `bin` 目录的路径，例如：
+
+  ```
+  /Users/yourname/openocd-0.12.0/bin
+  ```
+
+  将 `bin` 目录加入 `PATH`（与上述工具链配置方式相同）。
+
+**在终端中运行以下命令验证环境是否就绪：**
+
+```sh
+arm-none-eabi-gcc --version
+cmake --version
+openocd --version
+```
+
+### 2. 构建项目
+
+#### 方式 A — CLion（推荐）
+
+1. 在 CLion 中打开项目根目录。
+2. 进入 **Settings → Build, Execution, Deployment → CMake**，设置 Arm GNU Toolchain 路径。
+3. **Windows** 用户还需将 **Generator** 设为 `Ninja`。
+4. 在工具栏中选择构建目标，点击 **Build**。
+
+#### 方式 B — 命令行
+
+```sh
+cd uicrm-embedded
+mkdir build && cd build
+cmake -DCMAKE_BUILD_TYPE=Release ..
+make -j$(nproc)
+```
+
+> **Windows** 用户请使用 `Ninja` 生成器：
+> ```sh
+> cmake -DCMAKE_BUILD_TYPE=Release .. -G "Ninja"
+> ninja -j
+> ```
+
+如需 GDB 调试，请将构建类型改为 `Debug` 或 `RelWithDebInfo`。
+注意 `Debug` 构建因关闭编译器优化，运行速度会明显变慢。
+
+### 3. 烧录固件
+
+#### 方式 A — CLion（推荐）
+
+选择目标，点击 **Run** 按钮（或点击 **Debug** 进行单步调试）。
+
+默认配置使用 **CMSIS-DAP** 调试器。如果使用 **ST-LINK**，请在 CLion 运行配置中切换调试探针。
+
+#### 方式 B — 命令行（OpenOCD）
+
+仓库在 `openocd/` 目录下提供了各 MCU 系列的 OpenOCD 配置文件。
+例如，烧录 DJI_Board_TypeC (STM32F4)：
+
+```sh
+openocd -f openocd/stm32f4/daplink.cfg
+```
+
+详见 [OpenOCD Flash Commands](https://openocd.org/doc/html/Flash-Commands.html)。
+
+
+### 4. 生成文档
+
+安装 [Doxygen](https://www.doxygen.nl/index.html)：
+
+- **macOS**：`brew install doxygen`
+- **Ubuntu**：`sudo apt install doxygen`
+- **Arch**：`sudo pacman -S doxygen`
+
+然后构建文档：
+
+```sh
+cd build
+make doc
+# 或（Windows）：ninja doc
+```
+
+在浏览器中打开 `docs/html/index.html` 即可查看。
+
+---
+
+## 开发指南
+
+参与本仓库开发的注意事项。
+
+### 编辑代码
+
+任意编辑器均可，推荐使用 [CLion](https://www.jetbrains.com/clion/)。
+
+### 代码格式化
+
+CI 系统会对所有源码进行代码风格检查。不符合规范的代码将无法通过格式化检查，不能合并入仓库。
+所有代码在合并前必须正确格式化。项目提供了集成构建命令帮助你自动格式化代码。
+
+**前置条件**：安装 `clang-format` **18.1.8**。若未安装，CMake 将不会创建格式化构建目标。
+
+* Linux 用户：
+
+  * 推荐使用固定版本的 LLVM 二进制：
+    [x86_64](https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-18.04.tar.xz)
+    [aarch64](https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang+llvm-18.1.8-aarch64-linux-gnu.tar.xz)
+    ```bash
+    tar -xf clang+llvm-18.1.8-*.tar.xz
+    cp clang+llvm-18.1.8-*/bin/clang-format /usr/local/bin/
+    clang-format --version
+    ```
+  * 或：`pip install clang-format==18.1.8`
+  * 避免在 Ubuntu 24.04 上使用 `apt install clang-format-18`——该软件包版本为 **18.1.3**，非 18.1.8。
+
+* macOS 用户：
+
+  * 推荐：`brew install llvm@18` 并确保 `clang-format` 18.1.8 在 `PATH` 中
+  * 或使用官方包（Apple Silicon）：
+    [Apple Silicon](https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang+llvm-18.1.8-arm64-apple-macos11.tar.xz)
+    ```bash
+    tar -xf clang+llvm-18.1.8-arm64-apple-macos11.tar.xz
+    cp clang+llvm-18.1.8-arm64-apple-macos11/bin/clang-format /usr/local/bin/
+    clang-format --version
+    ```
+  * 或：`pip install clang-format==18.1.8`
+
+* Windows 用户：
+
+  * [官方安装包](https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/LLVM-18.1.8-win64.exe)，安装后 `clang-format.exe` 位于 `C:\Program Files\LLVM\bin\`。
+
+
+**在 CLion 中格式化**
+
+选择格式化 CMake 构建目标并编译，CLion 会自动格式化代码。
+1. `check-format`：显示当前源码与格式化后源码的 `diff`（不修改文件）
+2. `format`：原地格式化所有源文件
+
+**命令行格式化**
+
+在 `build/` 目录下运行以下命令：
+
+1. `make check-format`（或 `ninja check-format`）：预览格式化差异
+2. `make format`（或 `ninja format`）：执行原地格式化
+
+### GDB 调试
+
+调试嵌入式目标需要远程 GDB 服务器，有两种选择：
+
+- **CLion Debugger** — 最便捷的方式。选择目标，在 CLion 中点击 **Debug** 按钮即可。
+
+- **OpenOCD** — 虽然可以直接使用 OpenOCD，但仅推荐高级用户使用。
+
+---
+
+## 贡献指南
+
+`main` 分支受保护。请创建新分支并发起 Pull Request 来合并你的修改。
+合并前<u>必须通过 CI 检查（格式化检查和构建检查）</u>。
+
+请编写有意义的提交信息，例如：
+`feat: 新增云台控制模块`。
+
+提交类型必须是以下之一：
+
+- **feat**：面向用户的新功能，非构建脚本的新功能
+- **fix**：面向用户的 bug 修复，非构建脚本的修复
+- **perf**：性能优化
+- **docs**：文档修改
+- **style**：格式化修改、缺失分号等
+- **refactor**：生产代码重构，如变量重命名
+- **test**：添加或重构测试；无生产代码修改
+- **build**：构建配置、开发工具等与用户无关的修改

--- a/boards/drivers/DJI_Board_TypeC/src/bsp_imu.cpp
+++ b/boards/drivers/DJI_Board_TypeC/src/bsp_imu.cpp
@@ -689,7 +689,6 @@ namespace bsp {
             INS_gyro[1] = BMI088_real_data_.gyro[1];
             INS_gyro[2] = BMI088_real_data_.gyro[2];
 
-
             accel_fliter_1[0] = accel_fliter_2[0];
             accel_fliter_2[0] = accel_fliter_3[0];
             accel_fliter_3[0] = accel_fliter_2[0] * fliter_num[0] + accel_fliter_1[0] * fliter_num[1] +

--- a/boards/drivers/include/protocol.h
+++ b/boards/drivers/include/protocol.h
@@ -145,15 +145,16 @@ namespace communication {
         bsp::EventThread* callback_thread_ = nullptr;
         static void callback_thread_func_(void* args);
 
-        const osThreadAttr_t callback_thread_attr_ = {.name = "ProtocolUpdateTask",
-                                                      .attr_bits = osThreadDetached,
-                                                      .cb_mem = nullptr,
-                                                      .cb_size = 0,
-                                                      .stack_mem = nullptr,
-                                                      .stack_size = 256 * 4,
-                                                      .priority = (osPriority_t)osPriorityHigh,
-                                                      .tz_module = 0,
-                                                      .reserved = 0};
+        const osThreadAttr_t callback_thread_attr_ =
+            {.name = "ProtocolUpdateTask",
+             .attr_bits = osThreadDetached,
+             .cb_mem = nullptr,
+             .cb_size = 0,
+             .stack_mem = nullptr,
+             .stack_size = 256 * 4,
+             .priority = (osPriority_t)osPriorityHigh,
+             .tz_module = 0,
+             .reserved = 0};
     };
 
 #ifndef NO_USB
@@ -176,15 +177,16 @@ namespace communication {
         bsp::EventThread* callback_thread_ = nullptr;
         static void callback_thread_func_(void* args);
 
-        const osThreadAttr_t callback_thread_attr_ = {.name = "ProtocolUpdateTask",
-                                                      .attr_bits = osThreadDetached,
-                                                      .cb_mem = nullptr,
-                                                      .cb_size = 0,
-                                                      .stack_mem = nullptr,
-                                                      .stack_size = 256 * 4,
-                                                      .priority = (osPriority_t)osPriorityHigh,
-                                                      .tz_module = 0,
-                                                      .reserved = 0};
+        const osThreadAttr_t callback_thread_attr_ =
+            {.name = "ProtocolUpdateTask",
+             .attr_bits = osThreadDetached,
+             .cb_mem = nullptr,
+             .cb_size = 0,
+             .stack_mem = nullptr,
+             .stack_size = 256 * 4,
+             .priority = (osPriority_t)osPriorityHigh,
+             .tz_module = 0,
+             .reserved = 0};
     };
 
 #endif
@@ -323,9 +325,9 @@ namespace communication {
 
     /* ===== POWER_HEAT_DATA 0x0202 50Hz ===== */
     typedef struct {
-        uint16_t chassis_volt; // reserved
-        uint16_t chassis_current; // reserved
-        float chassis_power; // reserved
+        uint16_t chassis_volt;     // reserved
+        uint16_t chassis_current;  // reserved
+        float chassis_power;       // reserved
         uint16_t chassis_power_buffer;
         uint16_t shooter_id1_17mm_cooling_heat;
         uint16_t shooter_id1_42mm_cooling_heat;
@@ -549,7 +551,7 @@ namespace communication {
 
     /* ===== CUSTOM_CLIENT_DATA 0x0306 ===== */
     typedef struct {
-        uint16_t key_value; // 按键值
+        uint16_t key_value;  // 按键值
         uint16_t x_position : 12;
         uint16_t mouse_left : 4;
         uint16_t y_position : 12;
@@ -738,8 +740,8 @@ namespace communication {
         uint8_t robot_id;
         uint8_t vision_reset;      // 是否重置视觉识别
         uint8_t location_data[2];  // 裁判系统返回的位置数据，RMUL状态下为0
-        uint8_t is_killed;  // 是否被击杀，裁判系统血量为0或者触发手动kill则视为被击杀
-        uint8_t robot_mode;  // 机器人模式
+        uint8_t is_killed;         // 是否被击杀，裁判系统血量为0或者触发手动kill则视为被击杀
+        uint8_t robot_mode;        // 机器人模式
         /*
          * 1:一般跟随
          * 2:小陀螺

--- a/boards/drivers/src/protocol.cpp
+++ b/boards/drivers/src/protocol.cpp
@@ -53,15 +53,11 @@ namespace communication {
 
                 if (rx_state.idx >= FRAME_HEADER_LEN + CMD_ID_LEN + FRAME_TAIL_LEN) {
                     int DATA_LENGTH = bufferRx[2] << BYTE | bufferRx[1];
-                    if (rx_state.idx >=
-                        FRAME_HEADER_LEN + CMD_ID_LEN + DATA_LENGTH + FRAME_TAIL_LEN) {
+                    if (rx_state.idx >= FRAME_HEADER_LEN + CMD_ID_LEN + DATA_LENGTH + FRAME_TAIL_LEN) {
                         if (VerifyHeader(bufferRx, FRAME_HEADER_LEN) &&
-                            VerifyFrame(bufferRx, FRAME_HEADER_LEN + CMD_ID_LEN + DATA_LENGTH +
-                                                  FRAME_TAIL_LEN)) {
-                            int cmd_id =
-                                bufferRx[FRAME_HEADER_LEN + 1] << BYTE | bufferRx[FRAME_HEADER_LEN];
-                            ProcessDataRx(cmd_id, bufferRx + FRAME_HEADER_LEN + CMD_ID_LEN,
-                                          DATA_LENGTH);
+                            VerifyFrame(bufferRx, FRAME_HEADER_LEN + CMD_ID_LEN + DATA_LENGTH + FRAME_TAIL_LEN)) {
+                            int cmd_id = bufferRx[FRAME_HEADER_LEN + 1] << BYTE | bufferRx[FRAME_HEADER_LEN];
+                            ProcessDataRx(cmd_id, bufferRx + FRAME_HEADER_LEN + CMD_ID_LEN, DATA_LENGTH);
                         }
                         rx_state.mode = rx_state.WAITING_FOR_SOF;
                         rx_state.idx = 0;
@@ -133,8 +129,7 @@ namespace communication {
 
     void UARTProtocol::callback_thread_func_(void* args) {
         UARTProtocol* uart_protocol_ = reinterpret_cast<UARTProtocol*>(args);
-        uart_protocol_->Receive(
-            communication::package_t{uart_protocol_->read_ptr_, (int)uart_protocol_->read_len_});
+        uart_protocol_->Receive(communication::package_t{uart_protocol_->read_ptr_, (int)uart_protocol_->read_len_});
     }
 
     UARTProtocol::~UARTProtocol() {
@@ -149,8 +144,7 @@ namespace communication {
 
 #ifndef NO_USB
 
-    USBProtocol::USBProtocol(bsp::VirtualUSB* usb, uint32_t txBufferSize = 200,
-                             uint32_t rxBufferSize = 200)
+    USBProtocol::USBProtocol(bsp::VirtualUSB* usb, uint32_t txBufferSize = 200, uint32_t rxBufferSize = 200)
         : Protocol() {
         usb_ = usb;
         usb_->SetupTx(txBufferSize);
@@ -172,8 +166,9 @@ namespace communication {
 
     void USBProtocol::callback_thread_func_(void* args) {
         USBProtocol* usb_protocol_ = reinterpret_cast<USBProtocol*>(args);
-        usb_protocol_->Receive(communication::package_t{
-            usb_protocol_->read_ptr_, static_cast<int>(usb_protocol_->read_len_)});
+        usb_protocol_->Receive(
+            communication::package_t{usb_protocol_->read_ptr_, static_cast<int>(usb_protocol_->read_len_)}
+        );
     }
 
     USBProtocol::~USBProtocol() {

--- a/boards/platform/stm32f1/include/bsp_gpio.h
+++ b/boards/platform/stm32f1/include/bsp_gpio.h
@@ -35,7 +35,7 @@ namespace bsp {
      * @details used for GPIO input and output
      */
     class GPIO {
-    public:
+      public:
         /**
          * @brief 构造函数，用于通用GPIO（非中断）
          *
@@ -87,7 +87,7 @@ namespace bsp {
          */
         uint8_t Read();
 
-    private:
+      private:
         GPIO_TypeDef* group_;
         uint16_t pin_;
         uint8_t state_;
@@ -104,7 +104,7 @@ namespace bsp {
      * @details used for general purpose interrupt pin management
      */
     class GPIT {
-    public:
+      public:
         /**
          * @brief 构造函数，用于通用中断引脚
          *
@@ -150,16 +150,14 @@ namespace bsp {
          */
         static void IntCallback(uint16_t pin);
 
-    private:
+      private:
         static int GetGPIOIndex(uint16_t pin);
 
         static GPIT* gpits[NUM_GPITS];
 
         uint16_t pin_;
 
-        gpit_callback_t callback_ = [](void* args) {
-            UNUSED(args);
-        };
+        gpit_callback_t callback_ = [](void* args) { UNUSED(args); };
 
         void* args_ = nullptr;
     };

--- a/boards/platform/stm32f1/src/bsp_gpio.cpp
+++ b/boards/platform/stm32f1/src/bsp_gpio.cpp
@@ -28,22 +28,21 @@ namespace bsp {
     }
 
     /**
-    * @brief 构造函数，用于需要自定义输入模式/上下拉的 GPIO（非中断）。
-    *
-    * 该构造函数允许在创建 GPIO 对象时直接配置引脚的模式（输入/输出）和上下拉电阻。
-    * 通常用于按键、开关等需要上拉或下拉输入的场景。
-    *
-    * @param group GPIO 端口组（如 GPIOB、GPIOC）。
-    * @param pin   GPIO 引脚号（如 GPIO_PIN_12）。
-    * @param mode  引脚模式，可取 GPIO_MODE_INPUT、GPIO_MODE_OUTPUT_PP 等（HAL 定义）。
-    * @param pull  上下拉配置，可取 GPIO_NOPULL、GPIO_PULLUP、GPIO_PULLDOWN。
-    */
-    GPIO::GPIO(GPIO_TypeDef* group, uint16_t pin, uint32_t mode, uint32_t pull)
-    : group_(group), pin_(pin), state_(0) {
+     * @brief 构造函数，用于需要自定义输入模式/上下拉的 GPIO（非中断）。
+     *
+     * 该构造函数允许在创建 GPIO 对象时直接配置引脚的模式（输入/输出）和上下拉电阻。
+     * 通常用于按键、开关等需要上拉或下拉输入的场景。
+     *
+     * @param group GPIO 端口组（如 GPIOB、GPIOC）。
+     * @param pin   GPIO 引脚号（如 GPIO_PIN_12）。
+     * @param mode  引脚模式，可取 GPIO_MODE_INPUT、GPIO_MODE_OUTPUT_PP 等（HAL 定义）。
+     * @param pull  上下拉配置，可取 GPIO_NOPULL、GPIO_PULLUP、GPIO_PULLDOWN。
+     */
+    GPIO::GPIO(GPIO_TypeDef* group, uint16_t pin, uint32_t mode, uint32_t pull) : group_(group), pin_(pin), state_(0) {
         GPIO_InitTypeDef init = {};
         init.Pin = pin;
-        init.Mode = mode;        // GPIO_MODE_INPUT
-        init.Pull = pull;        // GPIO_PULLUP
+        init.Mode = mode;  // GPIO_MODE_INPUT
+        init.Pull = pull;  // GPIO_PULLUP
         init.Speed = GPIO_SPEED_FREQ_LOW;
         HAL_GPIO_Init(group, &init);
     }

--- a/boards/platform/stm32f1/src/bsp_uart.cpp
+++ b/boards/platform/stm32f1/src/bsp_uart.cpp
@@ -32,8 +32,9 @@
 namespace bsp {
 
     /* modified version of HAL_UART_Receive_DMA */
-    static HAL_StatusTypeDef UartStartDmaNoInt(UART_HandleTypeDef* huart, uint8_t* data0,
-                                               uint8_t* data1, uint16_t size) {
+    static HAL_StatusTypeDef UartStartDmaNoInt(
+        UART_HandleTypeDef* huart, uint8_t* data0, uint8_t* data1, uint16_t size
+    ) {
         /* Check that a Rx process is not already ongoing */
         if (huart->RxState == HAL_UART_STATE_READY) {
             if ((data0 == NULL) || (data1 == NULL) || (size == 0U))
@@ -47,8 +48,13 @@ namespace bsp {
 
             /* Enable the DMA stream */
 #ifdef BOARD_HAS_UART_DMA_DOUBLE_BUFFER
-            HAL_DMAEx_MultiBufferStart(huart->hdmarx, (uint32_t)&huart->Instance->DR,
-                                       (uint32_t)data0, (uint32_t)data1, size);
+            HAL_DMAEx_MultiBufferStart(
+                huart->hdmarx,
+                (uint32_t)&huart->Instance->DR,
+                (uint32_t)data0,
+                (uint32_t)data1,
+                size
+            );
 #else
             HAL_DMA_Start(huart->hdmarx, (uint32_t)&huart->Instance->DR, (uint32_t)data0, size);
 #endif
@@ -90,8 +96,7 @@ namespace bsp {
         if (!uart)
             return;
 
-        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_IDLE) &&
-            __HAL_UART_GET_IT_SOURCE(huart, UART_IT_IDLE)) {
+        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_IDLE) && __HAL_UART_GET_IT_SOURCE(huart, UART_IT_IDLE)) {
             uart->RxCompleteCallback();
             __HAL_UART_CLEAR_IDLEFLAG(huart);
         }
@@ -154,8 +159,7 @@ namespace bsp {
             /* enable uart rx dma transfer in back ground */
             UartStartDmaNoInt(huart_, rx_data_[0], rx_data_[1], rx_size_);
         } else {
-            HAL_UART_RegisterCallback(huart_, HAL_UART_RX_COMPLETE_CB_ID,
-                                      RxCompleteCallbackWrapper);
+            HAL_UART_RegisterCallback(huart_, HAL_UART_RX_COMPLETE_CB_ID, RxCompleteCallbackWrapper);
             HAL_UART_Receive_IT(huart_, rx_data_[0], rx_size_);
         }
 
@@ -216,8 +220,7 @@ namespace bsp {
 #else
         // software double buffer
         HAL_DMA_Abort(huart_->hdmarx);
-        HAL_DMA_Start(huart_->hdmarx, (uint32_t)&huart_->Instance->DR,
-                      (uint32_t)rx_data_[rx_index_], rx_size_);
+        HAL_DMA_Start(huart_->hdmarx, (uint32_t)&huart_->Instance->DR, (uint32_t)rx_data_[rx_index_], rx_size_);
 #endif
 
         // exit critical session

--- a/boards/platform/stm32f4/src/bsp_uart.cpp
+++ b/boards/platform/stm32f4/src/bsp_uart.cpp
@@ -32,8 +32,9 @@
 namespace bsp {
 
     /* modified version of HAL_UART_Receive_DMA */
-    static HAL_StatusTypeDef UartStartDmaNoInt(UART_HandleTypeDef* huart, uint8_t* data0,
-                                               uint8_t* data1, uint16_t size) {
+    static HAL_StatusTypeDef UartStartDmaNoInt(
+        UART_HandleTypeDef* huart, uint8_t* data0, uint8_t* data1, uint16_t size
+    ) {
         /* Check that a Rx process is not already ongoing */
         if (huart->RxState == HAL_UART_STATE_READY) {
             if ((data0 == NULL) || (data1 == NULL) || (size == 0U))
@@ -47,8 +48,13 @@ namespace bsp {
 
             /* Enable the DMA stream */
 #ifdef BOARD_HAS_UART_DMA_DOUBLE_BUFFER
-            HAL_DMAEx_MultiBufferStart(huart->hdmarx, (uint32_t)&huart->Instance->DR,
-                                       (uint32_t)data0, (uint32_t)data1, size);
+            HAL_DMAEx_MultiBufferStart(
+                huart->hdmarx,
+                (uint32_t)&huart->Instance->DR,
+                (uint32_t)data0,
+                (uint32_t)data1,
+                size
+            );
 #else
             HAL_DMA_Start(huart->hdmarx, (uint32_t)&huart->Instance->DR, (uint32_t)data0, size);
 #endif
@@ -90,8 +96,7 @@ namespace bsp {
         if (!uart)
             return;
 
-        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_IDLE) &&
-            __HAL_UART_GET_IT_SOURCE(huart, UART_IT_IDLE)) {
+        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_IDLE) && __HAL_UART_GET_IT_SOURCE(huart, UART_IT_IDLE)) {
             uart->RxCompleteCallback();
             __HAL_UART_CLEAR_IDLEFLAG(huart);
         }
@@ -154,8 +159,7 @@ namespace bsp {
             /* enable uart rx dma transfer in back ground */
             UartStartDmaNoInt(huart_, rx_data_[0], rx_data_[1], rx_size_);
         } else {
-            HAL_UART_RegisterCallback(huart_, HAL_UART_RX_COMPLETE_CB_ID,
-                                      RxCompleteCallbackWrapper);
+            HAL_UART_RegisterCallback(huart_, HAL_UART_RX_COMPLETE_CB_ID, RxCompleteCallbackWrapper);
             HAL_UART_Receive_IT(huart_, rx_data_[0], rx_size_);
         }
 
@@ -216,8 +220,7 @@ namespace bsp {
 #else
         // software double buffer
         HAL_DMA_Abort(huart_->hdmarx);
-        HAL_DMA_Start(huart_->hdmarx, (uint32_t)&huart_->Instance->DR,
-                      (uint32_t)rx_data_[rx_index_], rx_size_);
+        HAL_DMA_Start(huart_->hdmarx, (uint32_t)&huart_->Instance->DR, (uint32_t)rx_data_[rx_index_], rx_size_);
 #endif
 
         // exit critical session

--- a/cmake/clang_format.cmake
+++ b/cmake/clang_format.cmake
@@ -1,7 +1,4 @@
 # use clang-format to enforce coding styles
-# NOTE: This project requires clang-format 18.
-#   macOS:  brew install clang-format@18
-#   Ubuntu: sudo apt install clang-format-18
 find_program(CLANG_FORMAT_EXE NAMES clang-format)
 # log the detected clang-format version and path
 if (CLANG_FORMAT_EXE)
@@ -9,8 +6,8 @@ if (CLANG_FORMAT_EXE)
             OUTPUT_VARIABLE CLANG_FORMAT_VERSION
             OUTPUT_STRIP_TRAILING_WHITESPACE)
     message(STATUS "Using clang-format: ${CLANG_FORMAT_EXE} (${CLANG_FORMAT_VERSION})")
-    if (NOT CLANG_FORMAT_VERSION MATCHES "version 18")
-        message(WARNING "clang-format version 18 is required to match CI. Detected: ${CLANG_FORMAT_VERSION}")
+    if (NOT CLANG_FORMAT_VERSION MATCHES "version 18.1.8")
+        message(WARNING "clang-format version 18.1.8 is required to match CI. Detected: ${CLANG_FORMAT_VERSION}")
     endif()
 endif()
 # gather all source code

--- a/cmake/clang_format.cmake
+++ b/cmake/clang_format.cmake
@@ -1,15 +1,17 @@
 # use clang-format to enforce coding styles
-find_program(CLANG_FORMAT_EXE NAMES 
-    clang-format-10
-    clang-format-9
-    clang-format-8
-    clang-format)
+# NOTE: This project requires clang-format 18.
+#   macOS:  brew install clang-format@18
+#   Ubuntu: sudo apt install clang-format-18
+find_program(CLANG_FORMAT_EXE NAMES clang-format)
 # log the detected clang-format version and path
 if (CLANG_FORMAT_EXE)
     execute_process(COMMAND ${CLANG_FORMAT_EXE} --version
             OUTPUT_VARIABLE CLANG_FORMAT_VERSION
             OUTPUT_STRIP_TRAILING_WHITESPACE)
     message(STATUS "Using clang-format: ${CLANG_FORMAT_EXE} (${CLANG_FORMAT_VERSION})")
+    if (NOT CLANG_FORMAT_VERSION MATCHES "version 18")
+        message(WARNING "clang-format version 18 is required to match CI. Detected: ${CLANG_FORMAT_VERSION}")
+    endif()
 endif()
 # gather all source code
 file(GLOB_RECURSE ALL_SOURCE_FILES
@@ -25,7 +27,7 @@ list(FILTER ALL_SOURCE_FILES EXCLUDE REGEX .*/boards/.*)
 
 # create formatting helper targets
 if (CLANG_FORMAT_EXE)
-    # download a third party clang format python wrapper
+    # a third party clang-format python wrapper (respects .clang-format-ignore)
     set(RUN_CLANG_FORMAT ${CMAKE_SOURCE_DIR}/run-clang-format.py)
     if (CMAKE_HOST_SYSTEM_NAME MATCHES "Windows")
         message(STATUS "Current system is windows, clang-format should be proccess in dictionary.")
@@ -43,13 +45,13 @@ if (CLANG_FORMAT_EXE)
     else()
         # format code in place
         add_custom_target(format
-            COMMAND python3 ${RUN_CLANG_FORMAT} --clang-format-executable ${CLANG_FORMAT_EXE} -i ${ALL_SOURCE_FILES}
+            COMMAND python3 ${RUN_CLANG_FORMAT} --clang-format-executable ${CLANG_FORMAT_EXE} -i -r ${CMAKE_SOURCE_DIR}
             DEPENDS ${RUN_CLANG_FORMAT} 
             WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
         # check for format violations
         add_custom_target(check-format
-            COMMAND python3 ${RUN_CLANG_FORMAT} --clang-format-executable ${CLANG_FORMAT_EXE} ${ALL_SOURCE_FILES}
+            COMMAND python3 ${RUN_CLANG_FORMAT} --clang-format-executable ${CLANG_FORMAT_EXE} -r ${CMAKE_SOURCE_DIR}
             DEPENDS ${RUN_CLANG_FORMAT} 
             WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
     endif(CMAKE_HOST_SYSTEM_NAME MATCHES "Windows")


### PR DESCRIPTION
- 在CI中安装clang-format-18.1.8并通过update-alternatives设为默认；
- 更新CMake配置，移除对旧版本的查找
- 更新 readme，使新人更易理解项目
