### PR TITLE
fix: 修复CI中ARM GCC工具链下载并统一clang-format版本为18.1.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,11 +28,13 @@ jobs:
         tar -xf ~/gcc-arm-none-eabi.tar.xz --directory ~/arm-toolchain-v10-3 --strip-components=1
     - name: add system path
       run: echo "~/arm-toolchain-v10-3/bin" >> $GITHUB_PATH  # set environment variable
-    - name: install clang-format-18
+    # Pin exact patch version to match Homebrew / README (18.1.8).
+    # Ubuntu apt clang-format-18 is 18.1.3 and formats some macros differently.
+    - name: install clang-format 18.1.8
       run: |
-        sudo apt-get update
-        sudo apt-get install -y clang-format-18
-        sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-18 100
+        python3 -m pip install --user clang-format==18.1.8
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
+        "$HOME/.local/bin/clang-format" --version
     - name: cmake
       run: |
         mkdir build && cd build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,22 +12,26 @@ jobs:
     steps:
     # checkout
     - uses: actions/checkout@v3
-    # cached ARM toolchain
+    # cached ARM toolchain (12.3.Rel1)
     - name: cache ARM toolchain
       id: cache-arm
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
-        path: ~/arm-toolchain-v10-3
-        key: ${{ runner.os }}-arm-toolchain
-    # download ARM toolchain
+        path: ${{ runner.temp }}/arm-toolchain
+        key: ${{ runner.os }}-arm-toolchain-12.3.rel1
     - name: download ARM toolchain
       if: steps.cache-arm.outputs.cache-hit != 'true'
       run: |
-        wget -O ~/gcc-arm-none-eabi.tar.xz https://developer.arm.com/-/media/Files/downloads/gnu/12.3.rel1/binrel/arm-gnu-toolchain-12.3.rel1-x86_64-arm-none-eabi.tar.xz
-        mkdir ~/arm-toolchain-v10-3
-        tar -xf ~/gcc-arm-none-eabi.tar.xz --directory ~/arm-toolchain-v10-3 --strip-components=1
-    - name: add system path
-      run: echo "~/arm-toolchain-v10-3/bin" >> $GITHUB_PATH  # set environment variable
+        # Prefer Azure Blob URL; developer.arm.com redirect can be flaky in CI.
+        curl -fsSL -o "$RUNNER_TEMP/gcc-arm-none-eabi.tar.xz" \
+          "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/12.3.rel1/binrel/arm-gnu-toolchain-12.3.rel1-x86_64-arm-none-eabi.tar.xz"
+        mkdir -p "$RUNNER_TEMP/arm-toolchain"
+        tar -xf "$RUNNER_TEMP/gcc-arm-none-eabi.tar.xz" -C "$RUNNER_TEMP/arm-toolchain" --strip-components=1
+    - name: add ARM toolchain to PATH
+      # GITHUB_PATH must be absolute; quoted "~/..." is written literally and never expands.
+      run: |
+        echo "$RUNNER_TEMP/arm-toolchain/bin" >> "$GITHUB_PATH"
+        "$RUNNER_TEMP/arm-toolchain/bin/arm-none-eabi-gcc" --version
     # Pin exact patch version to match Homebrew / README (18.1.8).
     # Ubuntu apt clang-format-18 is 18.1.3 and formats some macros differently.
     - name: install clang-format 18.1.8

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,11 @@ jobs:
         tar -xf ~/gcc-arm-none-eabi.tar.xz --directory ~/arm-toolchain-v10-3 --strip-components=1
     - name: add system path
       run: echo "~/arm-toolchain-v10-3/bin" >> $GITHUB_PATH  # set environment variable
+    - name: install clang-format-18
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang-format-18
+        sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-18 100
     - name: cmake
       run: |
         mkdir build && cd build

--- a/README.md
+++ b/README.md
@@ -123,33 +123,30 @@ formatting check will fail and the code will not be merged.
 All codes are required to be formatted correctly before merging. There are several
 integrated build commands that can help you automatically format your changes.
 
-**Prerequisite**: install `clang-format` version 18. (otherwise CMake will not create the format target)
+**Prerequisite**: install `clang-format` **18.1.8**. CMake will not create the format target if `clang-format` is missing.
 
 * For Linux users:
 
-  * Recommend`sudo apt install clang-format-18`
-  
-  * LLVM released packages(fallback)
-    [x86_64 (most common)](https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-22.04.tar.xz)
-    [aarch64 (ARM64)](https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang+llvm-18.1.8-aarch64-linux-gnu.tar.xz)
-    Install by:
+  * Prefer the pinned LLVM binary (matches CI / macOS Homebrew `18.1.8`):
+    [x86_64](https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-18.04.tar.xz)
+    [aarch64](https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang+llvm-18.1.8-aarch64-linux-gnu.tar.xz)
     ```bash
     tar -xf clang+llvm-18.1.8-*.tar.xz
-    export PATH=$PWD/clang+llvm-18.1.8/bin:$PATH
+    export PATH=$PWD/clang+llvm-18.1.8-*/bin:$PATH
     ```
-    
+  * Or: `pip install clang-format==18.1.8`
+  * Avoid `apt install clang-format-18` on Ubuntu 24.04 — that package is **18.1.3**, not 18.1.8.
   
 * For Mac users:
 
-  * [x86_64 (Intel Mac)](https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang+llvm-18.1.8-x86_64-apple-darwin.tar.xz)
-    [x86_64 (Apple Silicon)](https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang+llvm-18.1.8-arm64-apple-darwin.tar.xz)
-    Install by:
-    
+  * Recommend: `brew install llvm@18` then ensure `clang-format` 18.1.8 is on `PATH`
+  * Or official package:
+    [Apple Silicon](https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang+llvm-18.1.8-arm64-apple-macos11.tar.xz)
     ```bash
-    tar -xf clang+llvm-18.1.8-*.tar.xz
-    export PATH=$PWD/clang+llvm-18.1.8/bin:$PATH
+    tar -xf clang+llvm-18.1.8-arm64-apple-macos11.tar.xz
+    export PATH=$PWD/clang+llvm-18.1.8-arm64-apple-macos11/bin:$PATH
     ```
-
+  * Or: `pip install clang-format==18.1.8`
 * For Windows users:
 
   * [Official Installer](https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/LLVM-18.1.8-win64.exe) which files are going to locate `C:\Program Files\LLVM\bin\clang-format.exe` after installation.

--- a/boards/drivers/DJI_Board_TypeC/src/bsp_imu.cpp
+++ b/boards/drivers/DJI_Board_TypeC/src/bsp_imu.cpp
@@ -689,7 +689,6 @@ namespace bsp {
             INS_gyro[1] = BMI088_real_data_.gyro[1];
             INS_gyro[2] = BMI088_real_data_.gyro[2];
 
-
             accel_fliter_1[0] = accel_fliter_2[0];
             accel_fliter_2[0] = accel_fliter_3[0];
             accel_fliter_3[0] = accel_fliter_2[0] * fliter_num[0] + accel_fliter_1[0] * fliter_num[1] +

--- a/boards/drivers/include/protocol.h
+++ b/boards/drivers/include/protocol.h
@@ -145,15 +145,16 @@ namespace communication {
         bsp::EventThread* callback_thread_ = nullptr;
         static void callback_thread_func_(void* args);
 
-        const osThreadAttr_t callback_thread_attr_ = {.name = "ProtocolUpdateTask",
-                                                      .attr_bits = osThreadDetached,
-                                                      .cb_mem = nullptr,
-                                                      .cb_size = 0,
-                                                      .stack_mem = nullptr,
-                                                      .stack_size = 256 * 4,
-                                                      .priority = (osPriority_t)osPriorityHigh,
-                                                      .tz_module = 0,
-                                                      .reserved = 0};
+        const osThreadAttr_t callback_thread_attr_ =
+            {.name = "ProtocolUpdateTask",
+             .attr_bits = osThreadDetached,
+             .cb_mem = nullptr,
+             .cb_size = 0,
+             .stack_mem = nullptr,
+             .stack_size = 256 * 4,
+             .priority = (osPriority_t)osPriorityHigh,
+             .tz_module = 0,
+             .reserved = 0};
     };
 
 #ifndef NO_USB
@@ -176,15 +177,16 @@ namespace communication {
         bsp::EventThread* callback_thread_ = nullptr;
         static void callback_thread_func_(void* args);
 
-        const osThreadAttr_t callback_thread_attr_ = {.name = "ProtocolUpdateTask",
-                                                      .attr_bits = osThreadDetached,
-                                                      .cb_mem = nullptr,
-                                                      .cb_size = 0,
-                                                      .stack_mem = nullptr,
-                                                      .stack_size = 256 * 4,
-                                                      .priority = (osPriority_t)osPriorityHigh,
-                                                      .tz_module = 0,
-                                                      .reserved = 0};
+        const osThreadAttr_t callback_thread_attr_ =
+            {.name = "ProtocolUpdateTask",
+             .attr_bits = osThreadDetached,
+             .cb_mem = nullptr,
+             .cb_size = 0,
+             .stack_mem = nullptr,
+             .stack_size = 256 * 4,
+             .priority = (osPriority_t)osPriorityHigh,
+             .tz_module = 0,
+             .reserved = 0};
     };
 
 #endif
@@ -323,9 +325,9 @@ namespace communication {
 
     /* ===== POWER_HEAT_DATA 0x0202 50Hz ===== */
     typedef struct {
-        uint16_t chassis_volt; // reserved
-        uint16_t chassis_current; // reserved
-        float chassis_power; // reserved
+        uint16_t chassis_volt;     // reserved
+        uint16_t chassis_current;  // reserved
+        float chassis_power;       // reserved
         uint16_t chassis_power_buffer;
         uint16_t shooter_id1_17mm_cooling_heat;
         uint16_t shooter_id1_42mm_cooling_heat;
@@ -549,7 +551,7 @@ namespace communication {
 
     /* ===== CUSTOM_CLIENT_DATA 0x0306 ===== */
     typedef struct {
-        uint16_t key_value; // 按键值
+        uint16_t key_value;  // 按键值
         uint16_t x_position : 12;
         uint16_t mouse_left : 4;
         uint16_t y_position : 12;
@@ -738,8 +740,8 @@ namespace communication {
         uint8_t robot_id;
         uint8_t vision_reset;      // 是否重置视觉识别
         uint8_t location_data[2];  // 裁判系统返回的位置数据，RMUL状态下为0
-        uint8_t is_killed;  // 是否被击杀，裁判系统血量为0或者触发手动kill则视为被击杀
-        uint8_t robot_mode;  // 机器人模式
+        uint8_t is_killed;         // 是否被击杀，裁判系统血量为0或者触发手动kill则视为被击杀
+        uint8_t robot_mode;        // 机器人模式
         /*
          * 1:一般跟随
          * 2:小陀螺

--- a/boards/drivers/src/protocol.cpp
+++ b/boards/drivers/src/protocol.cpp
@@ -53,15 +53,11 @@ namespace communication {
 
                 if (rx_state.idx >= FRAME_HEADER_LEN + CMD_ID_LEN + FRAME_TAIL_LEN) {
                     int DATA_LENGTH = bufferRx[2] << BYTE | bufferRx[1];
-                    if (rx_state.idx >=
-                        FRAME_HEADER_LEN + CMD_ID_LEN + DATA_LENGTH + FRAME_TAIL_LEN) {
+                    if (rx_state.idx >= FRAME_HEADER_LEN + CMD_ID_LEN + DATA_LENGTH + FRAME_TAIL_LEN) {
                         if (VerifyHeader(bufferRx, FRAME_HEADER_LEN) &&
-                            VerifyFrame(bufferRx, FRAME_HEADER_LEN + CMD_ID_LEN + DATA_LENGTH +
-                                                  FRAME_TAIL_LEN)) {
-                            int cmd_id =
-                                bufferRx[FRAME_HEADER_LEN + 1] << BYTE | bufferRx[FRAME_HEADER_LEN];
-                            ProcessDataRx(cmd_id, bufferRx + FRAME_HEADER_LEN + CMD_ID_LEN,
-                                          DATA_LENGTH);
+                            VerifyFrame(bufferRx, FRAME_HEADER_LEN + CMD_ID_LEN + DATA_LENGTH + FRAME_TAIL_LEN)) {
+                            int cmd_id = bufferRx[FRAME_HEADER_LEN + 1] << BYTE | bufferRx[FRAME_HEADER_LEN];
+                            ProcessDataRx(cmd_id, bufferRx + FRAME_HEADER_LEN + CMD_ID_LEN, DATA_LENGTH);
                         }
                         rx_state.mode = rx_state.WAITING_FOR_SOF;
                         rx_state.idx = 0;
@@ -133,8 +129,7 @@ namespace communication {
 
     void UARTProtocol::callback_thread_func_(void* args) {
         UARTProtocol* uart_protocol_ = reinterpret_cast<UARTProtocol*>(args);
-        uart_protocol_->Receive(
-            communication::package_t{uart_protocol_->read_ptr_, (int)uart_protocol_->read_len_});
+        uart_protocol_->Receive(communication::package_t{uart_protocol_->read_ptr_, (int)uart_protocol_->read_len_});
     }
 
     UARTProtocol::~UARTProtocol() {
@@ -149,8 +144,7 @@ namespace communication {
 
 #ifndef NO_USB
 
-    USBProtocol::USBProtocol(bsp::VirtualUSB* usb, uint32_t txBufferSize = 200,
-                             uint32_t rxBufferSize = 200)
+    USBProtocol::USBProtocol(bsp::VirtualUSB* usb, uint32_t txBufferSize = 200, uint32_t rxBufferSize = 200)
         : Protocol() {
         usb_ = usb;
         usb_->SetupTx(txBufferSize);
@@ -172,8 +166,9 @@ namespace communication {
 
     void USBProtocol::callback_thread_func_(void* args) {
         USBProtocol* usb_protocol_ = reinterpret_cast<USBProtocol*>(args);
-        usb_protocol_->Receive(communication::package_t{
-            usb_protocol_->read_ptr_, static_cast<int>(usb_protocol_->read_len_)});
+        usb_protocol_->Receive(
+            communication::package_t{usb_protocol_->read_ptr_, static_cast<int>(usb_protocol_->read_len_)}
+        );
     }
 
     USBProtocol::~USBProtocol() {

--- a/boards/platform/stm32f1/include/bsp_gpio.h
+++ b/boards/platform/stm32f1/include/bsp_gpio.h
@@ -35,7 +35,7 @@ namespace bsp {
      * @details used for GPIO input and output
      */
     class GPIO {
-    public:
+      public:
         /**
          * @brief 构造函数，用于通用GPIO（非中断）
          *
@@ -87,7 +87,7 @@ namespace bsp {
          */
         uint8_t Read();
 
-    private:
+      private:
         GPIO_TypeDef* group_;
         uint16_t pin_;
         uint8_t state_;
@@ -104,7 +104,7 @@ namespace bsp {
      * @details used for general purpose interrupt pin management
      */
     class GPIT {
-    public:
+      public:
         /**
          * @brief 构造函数，用于通用中断引脚
          *
@@ -150,16 +150,14 @@ namespace bsp {
          */
         static void IntCallback(uint16_t pin);
 
-    private:
+      private:
         static int GetGPIOIndex(uint16_t pin);
 
         static GPIT* gpits[NUM_GPITS];
 
         uint16_t pin_;
 
-        gpit_callback_t callback_ = [](void* args) {
-            UNUSED(args);
-        };
+        gpit_callback_t callback_ = [](void* args) { UNUSED(args); };
 
         void* args_ = nullptr;
     };

--- a/boards/platform/stm32f1/src/bsp_gpio.cpp
+++ b/boards/platform/stm32f1/src/bsp_gpio.cpp
@@ -28,22 +28,21 @@ namespace bsp {
     }
 
     /**
-    * @brief 构造函数，用于需要自定义输入模式/上下拉的 GPIO（非中断）。
-    *
-    * 该构造函数允许在创建 GPIO 对象时直接配置引脚的模式（输入/输出）和上下拉电阻。
-    * 通常用于按键、开关等需要上拉或下拉输入的场景。
-    *
-    * @param group GPIO 端口组（如 GPIOB、GPIOC）。
-    * @param pin   GPIO 引脚号（如 GPIO_PIN_12）。
-    * @param mode  引脚模式，可取 GPIO_MODE_INPUT、GPIO_MODE_OUTPUT_PP 等（HAL 定义）。
-    * @param pull  上下拉配置，可取 GPIO_NOPULL、GPIO_PULLUP、GPIO_PULLDOWN。
-    */
-    GPIO::GPIO(GPIO_TypeDef* group, uint16_t pin, uint32_t mode, uint32_t pull)
-    : group_(group), pin_(pin), state_(0) {
+     * @brief 构造函数，用于需要自定义输入模式/上下拉的 GPIO（非中断）。
+     *
+     * 该构造函数允许在创建 GPIO 对象时直接配置引脚的模式（输入/输出）和上下拉电阻。
+     * 通常用于按键、开关等需要上拉或下拉输入的场景。
+     *
+     * @param group GPIO 端口组（如 GPIOB、GPIOC）。
+     * @param pin   GPIO 引脚号（如 GPIO_PIN_12）。
+     * @param mode  引脚模式，可取 GPIO_MODE_INPUT、GPIO_MODE_OUTPUT_PP 等（HAL 定义）。
+     * @param pull  上下拉配置，可取 GPIO_NOPULL、GPIO_PULLUP、GPIO_PULLDOWN。
+     */
+    GPIO::GPIO(GPIO_TypeDef* group, uint16_t pin, uint32_t mode, uint32_t pull) : group_(group), pin_(pin), state_(0) {
         GPIO_InitTypeDef init = {};
         init.Pin = pin;
-        init.Mode = mode;        // GPIO_MODE_INPUT
-        init.Pull = pull;        // GPIO_PULLUP
+        init.Mode = mode;  // GPIO_MODE_INPUT
+        init.Pull = pull;  // GPIO_PULLUP
         init.Speed = GPIO_SPEED_FREQ_LOW;
         HAL_GPIO_Init(group, &init);
     }

--- a/boards/platform/stm32f1/src/bsp_uart.cpp
+++ b/boards/platform/stm32f1/src/bsp_uart.cpp
@@ -32,8 +32,9 @@
 namespace bsp {
 
     /* modified version of HAL_UART_Receive_DMA */
-    static HAL_StatusTypeDef UartStartDmaNoInt(UART_HandleTypeDef* huart, uint8_t* data0,
-                                               uint8_t* data1, uint16_t size) {
+    static HAL_StatusTypeDef UartStartDmaNoInt(
+        UART_HandleTypeDef* huart, uint8_t* data0, uint8_t* data1, uint16_t size
+    ) {
         /* Check that a Rx process is not already ongoing */
         if (huart->RxState == HAL_UART_STATE_READY) {
             if ((data0 == NULL) || (data1 == NULL) || (size == 0U))
@@ -47,8 +48,13 @@ namespace bsp {
 
             /* Enable the DMA stream */
 #ifdef BOARD_HAS_UART_DMA_DOUBLE_BUFFER
-            HAL_DMAEx_MultiBufferStart(huart->hdmarx, (uint32_t)&huart->Instance->DR,
-                                       (uint32_t)data0, (uint32_t)data1, size);
+            HAL_DMAEx_MultiBufferStart(
+                huart->hdmarx,
+                (uint32_t)&huart->Instance->DR,
+                (uint32_t)data0,
+                (uint32_t)data1,
+                size
+            );
 #else
             HAL_DMA_Start(huart->hdmarx, (uint32_t)&huart->Instance->DR, (uint32_t)data0, size);
 #endif
@@ -90,8 +96,7 @@ namespace bsp {
         if (!uart)
             return;
 
-        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_IDLE) &&
-            __HAL_UART_GET_IT_SOURCE(huart, UART_IT_IDLE)) {
+        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_IDLE) && __HAL_UART_GET_IT_SOURCE(huart, UART_IT_IDLE)) {
             uart->RxCompleteCallback();
             __HAL_UART_CLEAR_IDLEFLAG(huart);
         }
@@ -154,8 +159,7 @@ namespace bsp {
             /* enable uart rx dma transfer in back ground */
             UartStartDmaNoInt(huart_, rx_data_[0], rx_data_[1], rx_size_);
         } else {
-            HAL_UART_RegisterCallback(huart_, HAL_UART_RX_COMPLETE_CB_ID,
-                                      RxCompleteCallbackWrapper);
+            HAL_UART_RegisterCallback(huart_, HAL_UART_RX_COMPLETE_CB_ID, RxCompleteCallbackWrapper);
             HAL_UART_Receive_IT(huart_, rx_data_[0], rx_size_);
         }
 
@@ -216,8 +220,7 @@ namespace bsp {
 #else
         // software double buffer
         HAL_DMA_Abort(huart_->hdmarx);
-        HAL_DMA_Start(huart_->hdmarx, (uint32_t)&huart_->Instance->DR,
-                      (uint32_t)rx_data_[rx_index_], rx_size_);
+        HAL_DMA_Start(huart_->hdmarx, (uint32_t)&huart_->Instance->DR, (uint32_t)rx_data_[rx_index_], rx_size_);
 #endif
 
         // exit critical session

--- a/boards/platform/stm32f4/src/bsp_uart.cpp
+++ b/boards/platform/stm32f4/src/bsp_uart.cpp
@@ -32,8 +32,9 @@
 namespace bsp {
 
     /* modified version of HAL_UART_Receive_DMA */
-    static HAL_StatusTypeDef UartStartDmaNoInt(UART_HandleTypeDef* huart, uint8_t* data0,
-                                               uint8_t* data1, uint16_t size) {
+    static HAL_StatusTypeDef UartStartDmaNoInt(
+        UART_HandleTypeDef* huart, uint8_t* data0, uint8_t* data1, uint16_t size
+    ) {
         /* Check that a Rx process is not already ongoing */
         if (huart->RxState == HAL_UART_STATE_READY) {
             if ((data0 == NULL) || (data1 == NULL) || (size == 0U))
@@ -47,8 +48,13 @@ namespace bsp {
 
             /* Enable the DMA stream */
 #ifdef BOARD_HAS_UART_DMA_DOUBLE_BUFFER
-            HAL_DMAEx_MultiBufferStart(huart->hdmarx, (uint32_t)&huart->Instance->DR,
-                                       (uint32_t)data0, (uint32_t)data1, size);
+            HAL_DMAEx_MultiBufferStart(
+                huart->hdmarx,
+                (uint32_t)&huart->Instance->DR,
+                (uint32_t)data0,
+                (uint32_t)data1,
+                size
+            );
 #else
             HAL_DMA_Start(huart->hdmarx, (uint32_t)&huart->Instance->DR, (uint32_t)data0, size);
 #endif
@@ -90,8 +96,7 @@ namespace bsp {
         if (!uart)
             return;
 
-        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_IDLE) &&
-            __HAL_UART_GET_IT_SOURCE(huart, UART_IT_IDLE)) {
+        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_IDLE) && __HAL_UART_GET_IT_SOURCE(huart, UART_IT_IDLE)) {
             uart->RxCompleteCallback();
             __HAL_UART_CLEAR_IDLEFLAG(huart);
         }
@@ -154,8 +159,7 @@ namespace bsp {
             /* enable uart rx dma transfer in back ground */
             UartStartDmaNoInt(huart_, rx_data_[0], rx_data_[1], rx_size_);
         } else {
-            HAL_UART_RegisterCallback(huart_, HAL_UART_RX_COMPLETE_CB_ID,
-                                      RxCompleteCallbackWrapper);
+            HAL_UART_RegisterCallback(huart_, HAL_UART_RX_COMPLETE_CB_ID, RxCompleteCallbackWrapper);
             HAL_UART_Receive_IT(huart_, rx_data_[0], rx_size_);
         }
 
@@ -216,8 +220,7 @@ namespace bsp {
 #else
         // software double buffer
         HAL_DMA_Abort(huart_->hdmarx);
-        HAL_DMA_Start(huart_->hdmarx, (uint32_t)&huart_->Instance->DR,
-                      (uint32_t)rx_data_[rx_index_], rx_size_);
+        HAL_DMA_Start(huart_->hdmarx, (uint32_t)&huart_->Instance->DR, (uint32_t)rx_data_[rx_index_], rx_size_);
 #endif
 
         // exit critical session

--- a/cmake/clang_format.cmake
+++ b/cmake/clang_format.cmake
@@ -1,7 +1,4 @@
 # use clang-format to enforce coding styles
-# NOTE: This project requires clang-format 18.
-#   macOS:  brew install clang-format@18
-#   Ubuntu: sudo apt install clang-format-18
 find_program(CLANG_FORMAT_EXE NAMES clang-format)
 # log the detected clang-format version and path
 if (CLANG_FORMAT_EXE)
@@ -9,8 +6,8 @@ if (CLANG_FORMAT_EXE)
             OUTPUT_VARIABLE CLANG_FORMAT_VERSION
             OUTPUT_STRIP_TRAILING_WHITESPACE)
     message(STATUS "Using clang-format: ${CLANG_FORMAT_EXE} (${CLANG_FORMAT_VERSION})")
-    if (NOT CLANG_FORMAT_VERSION MATCHES "version 18")
-        message(WARNING "clang-format version 18 is required to match CI. Detected: ${CLANG_FORMAT_VERSION}")
+    if (NOT CLANG_FORMAT_VERSION MATCHES "version 18.1.8")
+        message(WARNING "clang-format version 18.1.8 is required to match CI. Detected: ${CLANG_FORMAT_VERSION}")
     endif()
 endif()
 # gather all source code

--- a/cmake/clang_format.cmake
+++ b/cmake/clang_format.cmake
@@ -1,15 +1,17 @@
 # use clang-format to enforce coding styles
-find_program(CLANG_FORMAT_EXE NAMES 
-    clang-format-10
-    clang-format-9
-    clang-format-8
-    clang-format)
+# NOTE: This project requires clang-format 18.
+#   macOS:  brew install clang-format@18
+#   Ubuntu: sudo apt install clang-format-18
+find_program(CLANG_FORMAT_EXE NAMES clang-format)
 # log the detected clang-format version and path
 if (CLANG_FORMAT_EXE)
     execute_process(COMMAND ${CLANG_FORMAT_EXE} --version
             OUTPUT_VARIABLE CLANG_FORMAT_VERSION
             OUTPUT_STRIP_TRAILING_WHITESPACE)
     message(STATUS "Using clang-format: ${CLANG_FORMAT_EXE} (${CLANG_FORMAT_VERSION})")
+    if (NOT CLANG_FORMAT_VERSION MATCHES "version 18")
+        message(WARNING "clang-format version 18 is required to match CI. Detected: ${CLANG_FORMAT_VERSION}")
+    endif()
 endif()
 # gather all source code
 file(GLOB_RECURSE ALL_SOURCE_FILES
@@ -25,7 +27,7 @@ list(FILTER ALL_SOURCE_FILES EXCLUDE REGEX .*/boards/.*)
 
 # create formatting helper targets
 if (CLANG_FORMAT_EXE)
-    # download a third party clang format python wrapper
+    # a third party clang-format python wrapper (respects .clang-format-ignore)
     set(RUN_CLANG_FORMAT ${CMAKE_SOURCE_DIR}/run-clang-format.py)
     if (CMAKE_HOST_SYSTEM_NAME MATCHES "Windows")
         message(STATUS "Current system is windows, clang-format should be proccess in dictionary.")
@@ -43,13 +45,13 @@ if (CLANG_FORMAT_EXE)
     else()
         # format code in place
         add_custom_target(format
-            COMMAND python3 ${RUN_CLANG_FORMAT} --clang-format-executable ${CLANG_FORMAT_EXE} -i ${ALL_SOURCE_FILES}
+            COMMAND python3 ${RUN_CLANG_FORMAT} --clang-format-executable ${CLANG_FORMAT_EXE} -i -r ${CMAKE_SOURCE_DIR}
             DEPENDS ${RUN_CLANG_FORMAT} 
             WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
         # check for format violations
         add_custom_target(check-format
-            COMMAND python3 ${RUN_CLANG_FORMAT} --clang-format-executable ${CLANG_FORMAT_EXE} ${ALL_SOURCE_FILES}
+            COMMAND python3 ${RUN_CLANG_FORMAT} --clang-format-executable ${CLANG_FORMAT_EXE} -r ${CMAKE_SOURCE_DIR}
             DEPENDS ${RUN_CLANG_FORMAT} 
             WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
     endif(CMAKE_HOST_SYSTEM_NAME MATCHES "Windows")


### PR DESCRIPTION
更新CI工作流以解决ARM GCC工具链下载的可靠性问题，同时固定clang-format版本以消除不同环境间的格式差异。

- 将ARM工具链缓存路径改为`runner.temp`，并使用Azure Blob存储的稳定下载链接，避免开发者官网重定向失败。
- 在CI中通过pip安装clang-format 18.1.8，确保与Homebrew及本地开发环境一致。
- 更新README文档，推荐使用pinned 18.1.8版本（pip或LLVM官方二进制包），并警告不要使用apt安装的18.1.3。
- 应用clang-format 18.1.8的格式化规则，统一整个代码库的代码风格（包括协议头、GPIO类、UART驱动等）。
- 调整CMake配置：仅搜索`clang-format`（去除版本号后缀），并在检测到非18.1.8版本时输出警告；同时将`format`和`check-format`目标改为递归扫描整个源码目录。